### PR TITLE
fixes #243 undo redo bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ lerna-debug.log
 lib-cjs/
 .vscode/
 .DS_Store
+coverage/

--- a/packages/forest/__tests__/compression.spec.ts
+++ b/packages/forest/__tests__/compression.spec.ts
@@ -1,4 +1,4 @@
-import { AnyEvent } from "../src/types";
+import { AnyEvent, CreateEvent } from "../src/types";
 import { compressEvents } from "../src/compression";
 import { componentTreeDef, cssTreeDef, forestDef } from "./forestDefExample";
 
@@ -23,6 +23,13 @@ test("patches are merged", () => {
   ];
   const compressedEvents = compressEvents(events, forestDef);
   expect(compressedEvents.length).toBe(1);
+  expect(compressedEvents[0]).toHaveProperty("state");
+  expect((compressedEvents[0]! as CreateEvent)["state"]).toHaveProperty(
+    "alias"
+  );
+  expect((compressedEvents[0]! as CreateEvent)["state"]["alias"]).toBe(
+    "alias2"
+  );
 });
 
 test("create & delete results in no event", () => {
@@ -63,4 +70,48 @@ test("deleting root tree node, results in no event for linked tree", () => {
   ];
   const compressedEvents = compressEvents(events, forestDef);
   expect(compressedEvents.length).toBe(0);
+});
+
+test("css tree is linked with comp tree", () => {
+  const events: AnyEvent[] = [
+    {
+      type: `CREATE$$${componentTreeDef.modulePath}`,
+      meta: {},
+      id: "comp1",
+      state: { parent: { id: "body", index: 0 } },
+    },
+    {
+      type: `PATCH$$${componentTreeDef.modulePath}`,
+      id: "comp1",
+      slice: { alias: "alias1" },
+    },
+    {
+      type: `PATCH$$${componentTreeDef.modulePath}`,
+      id: "comp1",
+      slice: { alias: "alias2" },
+    },
+    {
+      type: `CREATE$$${cssTreeDef.modulePath}`,
+      meta: {},
+      id: "css1",
+      state: {
+        parent: { id: "", index: 0 },
+        property: { styles: { height: "10px" } },
+      },
+    },
+    {
+      type: `LINK$$${cssTreeDef.modulePath}`,
+      childId: "css1",
+      refId: "comp1",
+    },
+  ];
+  const compressedEvents = compressEvents(events, forestDef);
+  expect(compressedEvents.length).toBe(3);
+  expect(compressedEvents[0]!).toHaveProperty("state");
+  expect((compressedEvents[0]! as CreateEvent)["state"]).toBeDefined();
+  expect(
+    (compressedEvents[0]! as CreateEvent)["state"]["property"]["styles"][
+      "height"
+    ]
+  ).toBe("10px");
 });

--- a/packages/forest/__tests__/compression.spec.ts
+++ b/packages/forest/__tests__/compression.spec.ts
@@ -1,0 +1,75 @@
+import { AnyEvent, CreateEvent } from "../src/types";
+import { compressEvents } from "../src/compression";
+
+test("patches are merged", () => {
+  const events: AnyEvent[] = [
+    {
+      type: "CREATE$$CompTreeId",
+      meta: {},
+      id: "comp1",
+      state: { parent: { id: "body", index: 0 } },
+    },
+    {
+      type: "PATCH$$CompTreeId",
+      id: "comp1",
+      slice: { alias: "alias1" },
+    },
+    {
+      type: "PATCH$$CompTreeId",
+      id: "comp1",
+      slice: { alias: "alias2" },
+    },
+  ];
+  const compressedEvents = compressEvents(events);
+  expect(compressedEvents.length).toBe(2);
+});
+
+test("create & delete results in no event", () => {
+  const events: AnyEvent[] = [
+    {
+      type: "CREATE$$CompTreeId",
+      meta: {},
+      id: "comp1",
+      state: { parent: { id: "body", index: 0 } },
+    },
+    {
+      type: "DELETE$$CompTreeId",
+      id: "comp1",
+    },
+  ];
+  const compressedEvents = compressEvents(events);
+  expect(compressedEvents.length).toBe(0);
+});
+
+test("re-create removes delete event from compressed event", () => {
+  const events: AnyEvent[] = [
+    {
+      type: "CREATE$$CompTreeId",
+      meta: {},
+      id: "comp1",
+      state: { parent: { id: "body", index: 0 } },
+    },
+    {
+      type: "PATCH$$CompTreeId",
+      id: "comp1",
+      slice: { alias: "alias1" },
+    },
+    {
+      type: "DELETE$$CompTreeId",
+      id: "comp1",
+    },
+    {
+      type: "CREATE$$CompTreeId",
+      id: "comp1",
+      meta: {},
+      state: { parent: { id: "body", index: 0 } },
+    },
+  ];
+  const compressedEvents = compressEvents(events);
+  expect(compressedEvents.length).toBe(1);
+  expect(compressedEvents[0]).toHaveProperty("state");
+  expect((compressedEvents[0] as CreateEvent)["state"]).toHaveProperty(
+    "parent"
+  );
+  expect((compressedEvents[0] as CreateEvent)["state"]).toHaveProperty("alias");
+});

--- a/packages/forest/__tests__/forest.spec.ts
+++ b/packages/forest/__tests__/forest.spec.ts
@@ -1,50 +1,12 @@
 import { createForest } from "../src/forest";
-import { ForestDef, TreeDef } from "../src/types";
-
-const componentTreeDef: TreeDef = {
-  id: "componentTreeId",
-  modulePath: "componentTreeModule",
-  defFn: () => {
-    return {
-      validateCreate(_event) {
-        return true;
-      },
-      validatePatch(_event) {
-        return true;
-      },
-      onCreate(_event) {},
-    };
-  },
-};
-
-const cssTreeDef: TreeDef = {
-  id: "cssTreeId",
-  modulePath: "cssTreeModule",
-  defFn: () => {
-    return {
-      validateCreate(_event) {
-        return true;
-      },
-      validatePatch(_event) {
-        return true;
-      },
-      onCreate(_event) {},
-    };
-  },
-};
-
-const forestDef: ForestDef = {
-  id: "forestId",
-  pkg: "forestPkg",
-  trees: [componentTreeDef, cssTreeDef],
-};
+import { componentTreeDef, forestDef } from "./forestDefExample";
 
 test("createForest fn returns a forest with trees", () => {
   const forest = createForest(forestDef);
   expect(forest).toBeDefined();
   expect(forest.tree).toBeDefined();
 
-  const compTree = forest.tree("componentTreeModule");
+  const compTree = forest.tree(componentTreeDef.modulePath);
   expect(compTree).toBeDefined();
   const cssTree = forest.tree("cssTreeModule");
   expect(cssTree).toBeDefined();
@@ -52,7 +14,7 @@ test("createForest fn returns a forest with trees", () => {
 
 test("nodes get created on calling handleEvent", () => {
   const forest = createForest(forestDef);
-  const compTree = forest.tree("componentTreeModule");
+  const compTree = forest.tree(componentTreeDef.modulePath);
   forest.handleEvents({
     name: "TEST_EVENTS",
     events: [
@@ -111,7 +73,7 @@ test("create after delete event, restores all nodes", () => {
     name: "TEST_EVENTS",
     events: [
       {
-        type: `CREATE$$componentTreeModule`,
+        type: `CREATE$$${componentTreeDef.modulePath}`,
         id: "comp1",
         meta: {},
         state: {
@@ -119,7 +81,7 @@ test("create after delete event, restores all nodes", () => {
         },
       },
       {
-        type: `CREATE$$componentTreeModule`,
+        type: `CREATE$$${componentTreeDef.modulePath}`,
         id: "comp2",
         meta: {},
         state: {
@@ -127,11 +89,11 @@ test("create after delete event, restores all nodes", () => {
         },
       },
       {
-        type: `DELETE$$componentTreeModule`,
+        type: `DELETE$$${componentTreeDef.modulePath}`,
         id: "comp1",
       },
       {
-        type: `CREATE$$componentTreeModule`,
+        type: `CREATE$$${componentTreeDef.modulePath}`,
         id: "comp1",
         meta: {},
         state: {

--- a/packages/forest/__tests__/forest.spec.ts
+++ b/packages/forest/__tests__/forest.spec.ts
@@ -66,7 +66,7 @@ test("delete event removes node and it's descendant", () => {
   expect(Object.keys(compTree!.nodes).length === 0).toBeTruthy();
 });
 
-test("create after delete event, restores all nodes", () => {
+test("create after delete event, DOES NOT restore all nodes", () => {
   const forest = createForest(forestDef);
   const compTree = forest.tree("componentTreeModule");
   forest.handleEvents({
@@ -104,7 +104,7 @@ test("create after delete event, restores all nodes", () => {
     meta: { agent: "server-sent" },
   });
   expect(compTree?.nodes).toBeDefined();
-  expect(Object.keys(compTree!.nodes).length).toBe(2);
+  expect(Object.keys(compTree!.nodes).length).toBe(1);
 });
 
 test("patch event updates state", () => {
@@ -135,7 +135,7 @@ test("patch event updates state", () => {
   expect(compTree!.nodes["comp1"]?.state["alias"]).toBe("comp1Alias");
 });
 
-test("create after delete event, restores all old state", () => {
+test("create after delete event, DOES not restore all old state", () => {
   const forest = createForest(forestDef);
   const compTree = forest.tree("componentTreeModule");
   forest.handleEvents({
@@ -172,5 +172,41 @@ test("create after delete event, restores all old state", () => {
     meta: { agent: "server-sent" },
   });
   expect(compTree?.nodes).toBeDefined();
-  expect(compTree!.nodes["comp1"]?.state["alias"]).toBe("comp1Alias");
+  expect(compTree!.nodes["comp1"]?.state["alias"]).toBeUndefined();
+});
+
+test("hard patch replaces state", () => {
+  const forest = createForest(forestDef);
+  const compTree = forest.tree("componentTreeModule");
+  forest.handleEvents({
+    name: "TEST_EVENTS",
+    events: [
+      {
+        type: `CREATE$$componentTreeModule`,
+        id: "comp1",
+        meta: {},
+        state: {
+          parent: { id: "body", index: 0 },
+        },
+      },
+      {
+        type: `PATCH$$componentTreeModule`,
+        id: "comp1",
+        slice: {
+          alias: "comp1Alias",
+        },
+      },
+      {
+        type: `HARDPATCH$$componentTreeModule`,
+        id: "comp1",
+        state: {
+          styles: { height: "10px" },
+        },
+      },
+    ],
+    meta: { agent: "server-sent" },
+  });
+  expect(compTree?.nodes).toBeDefined();
+  expect(compTree!.nodes["comp1"]!.state).toHaveProperty("styles");
+  expect(compTree!.nodes["comp1"]!.state).not.toHaveProperty("alias");
 });

--- a/packages/forest/__tests__/forest.spec.ts
+++ b/packages/forest/__tests__/forest.spec.ts
@@ -1,0 +1,5 @@
+import { createForest } from "../src/forest";
+
+test("create forest creates forests", () => {
+  expect("5").toEqual("5");
+});

--- a/packages/forest/__tests__/forest.spec.ts
+++ b/packages/forest/__tests__/forest.spec.ts
@@ -1,5 +1,214 @@
 import { createForest } from "../src/forest";
+import { ForestDef, TreeDef } from "../src/types";
 
-test("create forest creates forests", () => {
-  expect("5").toEqual("5");
+const componentTreeDef: TreeDef = {
+  id: "componentTreeId",
+  modulePath: "componentTreeModule",
+  defFn: () => {
+    return {
+      validateCreate(_event) {
+        return true;
+      },
+      validatePatch(_event) {
+        return true;
+      },
+      onCreate(_event) {},
+    };
+  },
+};
+
+const cssTreeDef: TreeDef = {
+  id: "cssTreeId",
+  modulePath: "cssTreeModule",
+  defFn: () => {
+    return {
+      validateCreate(_event) {
+        return true;
+      },
+      validatePatch(_event) {
+        return true;
+      },
+      onCreate(_event) {},
+    };
+  },
+};
+
+const forestDef: ForestDef = {
+  id: "forestId",
+  pkg: "forestPkg",
+  trees: [componentTreeDef, cssTreeDef],
+};
+
+test("createForest fn returns a forest with trees", () => {
+  const forest = createForest(forestDef);
+  expect(forest).toBeDefined();
+  expect(forest.tree).toBeDefined();
+
+  const compTree = forest.tree("componentTreeModule");
+  expect(compTree).toBeDefined();
+  const cssTree = forest.tree("cssTreeModule");
+  expect(cssTree).toBeDefined();
+});
+
+test("nodes get created on calling handleEvent", () => {
+  const forest = createForest(forestDef);
+  const compTree = forest.tree("componentTreeModule");
+  forest.handleEvents({
+    name: "TEST_EVENTS",
+    events: [
+      {
+        type: `CREATE$$componentTreeModule`,
+        id: "comp1",
+        meta: {},
+        state: {
+          parent: { id: "body", index: 0 },
+        },
+      },
+    ],
+    meta: { agent: "server-sent" },
+  });
+  expect(compTree?.nodes).toBeDefined();
+  expect(Object.keys(compTree!.nodes).length > 0).toBeTruthy();
+});
+
+test("delete event removes node and it's descendant", () => {
+  const forest = createForest(forestDef);
+  const compTree = forest.tree("componentTreeModule");
+  forest.handleEvents({
+    name: "TEST_EVENTS",
+    events: [
+      {
+        type: `CREATE$$componentTreeModule`,
+        id: "comp1",
+        meta: {},
+        state: {
+          parent: { id: "body", index: 0 },
+        },
+      },
+      {
+        type: `CREATE$$componentTreeModule`,
+        id: "comp2",
+        meta: {},
+        state: {
+          parent: { id: "comp1", index: 0 },
+        },
+      },
+      {
+        type: `DELETE$$componentTreeModule`,
+        id: "comp1",
+      },
+    ],
+    meta: { agent: "server-sent" },
+  });
+  expect(compTree?.nodes).toBeDefined();
+  expect(Object.keys(compTree!.nodes).length === 0).toBeTruthy();
+});
+
+test("create after delete event, restores all nodes", () => {
+  const forest = createForest(forestDef);
+  const compTree = forest.tree("componentTreeModule");
+  forest.handleEvents({
+    name: "TEST_EVENTS",
+    events: [
+      {
+        type: `CREATE$$componentTreeModule`,
+        id: "comp1",
+        meta: {},
+        state: {
+          parent: { id: "body", index: 0 },
+        },
+      },
+      {
+        type: `CREATE$$componentTreeModule`,
+        id: "comp2",
+        meta: {},
+        state: {
+          parent: { id: "comp1", index: 0 },
+        },
+      },
+      {
+        type: `DELETE$$componentTreeModule`,
+        id: "comp1",
+      },
+      {
+        type: `CREATE$$componentTreeModule`,
+        id: "comp1",
+        meta: {},
+        state: {
+          parent: { id: "body", index: 0 },
+        },
+      },
+    ],
+    meta: { agent: "server-sent" },
+  });
+  expect(compTree?.nodes).toBeDefined();
+  expect(Object.keys(compTree!.nodes).length).toBe(2);
+});
+
+test("patch event updates state", () => {
+  const forest = createForest(forestDef);
+  const compTree = forest.tree("componentTreeModule");
+  forest.handleEvents({
+    name: "TEST_EVENTS",
+    events: [
+      {
+        type: `CREATE$$componentTreeModule`,
+        id: "comp1",
+        meta: {},
+        state: {
+          parent: { id: "body", index: 0 },
+        },
+      },
+      {
+        type: `PATCH$$componentTreeModule`,
+        id: "comp1",
+        slice: {
+          alias: "comp1Alias",
+        },
+      },
+    ],
+    meta: { agent: "server-sent" },
+  });
+  expect(compTree?.nodes).toBeDefined();
+  expect(compTree!.nodes["comp1"]?.state["alias"]).toBe("comp1Alias");
+});
+
+test("create after delete event, restores all old state", () => {
+  const forest = createForest(forestDef);
+  const compTree = forest.tree("componentTreeModule");
+  forest.handleEvents({
+    name: "TEST_EVENTS",
+    events: [
+      {
+        type: `CREATE$$componentTreeModule`,
+        id: "comp1",
+        meta: {},
+        state: {
+          parent: { id: "body", index: 0 },
+        },
+      },
+      {
+        type: `PATCH$$componentTreeModule`,
+        id: "comp1",
+        slice: {
+          alias: "comp1Alias",
+        },
+      },
+      {
+        type: `DELETE$$componentTreeModule`,
+        id: "comp1",
+      },
+      {
+        type: `CREATE$$componentTreeModule`,
+        id: "comp1",
+        meta: {},
+        state: {
+          parent: { id: "body", index: 0 },
+        },
+      },
+    ],
+    meta: { agent: "server-sent" },
+  });
+  expect(compTree?.nodes).toBeDefined();
+  expect(compTree!.nodes["comp1"]?.state["alias"]).toBe("comp1Alias");
 });

--- a/packages/forest/__tests__/forestDefExample.ts
+++ b/packages/forest/__tests__/forestDefExample.ts
@@ -1,0 +1,39 @@
+import { ForestDef, TreeDef } from "../src/types";
+
+export const componentTreeDef: TreeDef = {
+  id: "componentTreeModule",
+  modulePath: "componentTreeModule",
+  defFn: () => {
+    return {
+      validateCreate(_event) {
+        return true;
+      },
+      validatePatch(_event) {
+        return true;
+      },
+      onCreate(_event) {},
+    };
+  },
+};
+
+export const cssTreeDef: TreeDef = {
+  id: "cssTreeModule",
+  modulePath: "cssTreeModule",
+  defFn: () => {
+    return {
+      validateCreate(_event) {
+        return true;
+      },
+      validatePatch(_event) {
+        return true;
+      },
+      onCreate(_event) {},
+    };
+  },
+};
+
+export const forestDef: ForestDef = {
+  id: "forestId",
+  pkg: "forestPkg",
+  trees: [componentTreeDef, cssTreeDef],
+};

--- a/packages/forest/jest.config.js
+++ b/packages/forest/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+};

--- a/packages/forest/jest.config.js
+++ b/packages/forest/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
+  modulePathIgnorePatterns: ["forestDefExample.ts"],
 };

--- a/packages/forest/package.json
+++ b/packages/forest/package.json
@@ -23,7 +23,9 @@
   "scripts": {
     "clean": "rimraf lib",
     "build": "tsc",
-    "prepublishOnly": "yarn run build"
+    "prepublishOnly": "yarn run build",
+    "test": "jest --coverage",
+    "test:watch": "jest --watch"
   },
   "bugs": {
     "url": "https://github.com/cruxcode/atrilabs-engine/issues"
@@ -34,7 +36,10 @@
     "typescript": "4.6.3"
   },
   "devDependencies": {
+    "@types/jest": "^29.1.2",
     "@types/lowdb": "1.0.11",
-    "@types/node": "17.0.27"
+    "@types/node": "17.0.27",
+    "jest": "^29.1.2",
+    "ts-jest": "^29.0.3"
   }
 }

--- a/packages/forest/src/compression.ts
+++ b/packages/forest/src/compression.ts
@@ -45,7 +45,7 @@ export function compressEvents(events: AnyEvent[], forestDef: ForestDef) {
 
       const reverseLinkMap: { [childId: string]: string } = {};
       linkRefIds.forEach((linkRefId) => {
-        return tree.links[linkRefId]!.childId;
+        reverseLinkMap[tree.links[linkRefId]!.childId] = linkRefId;
       });
 
       return nodeIds.map((nodeId): AnyEvent[] => {

--- a/packages/forest/src/compression.ts
+++ b/packages/forest/src/compression.ts
@@ -1,159 +1,82 @@
-import {
-  AnyEvent,
-  CreateEvent,
-  DeleteEvent,
-  LinkEvent,
-  PatchEvent,
-  UnlinkEvent,
-} from "./types";
-import { mergeWith } from "lodash";
-
-function mergeStateCustomizer(obj: any, src: any) {
-  // replace array instead of default merge
-  if (Array.isArray(obj)) {
-    return src;
-  }
-}
-
-function detectEventType(event: AnyEvent) {
-  const [eventType, treeId] = event.type.split("$$");
-  return { eventType, treeId };
-}
+import { AnyEvent, ForestDef } from "./types";
+import { createForest } from "./forest";
 
 /**
  * It implements a tree agnostic compression algorithm.
  * All patch events are merged. Only last link event is kept.
  * Only last unlink event is kept. A node is dropped if delete is emitted.
  */
-export function compressEvents(events: AnyEvent[]) {
-  const intermediateCompression: {
-    [treeId: string]: {
-      nodes: {
-        [nodeId: string]: {
-          create?: CreateEvent;
-          patch?: PatchEvent;
-          link?: LinkEvent;
-          unlink?: UnlinkEvent;
-          linkLast?: boolean;
-          creationIndex?: number;
-        };
-      };
-    };
-  } = {};
-  for (let i = 0; i < events.length; i++) {
-    const event = events[i]!;
-    const { eventType, treeId } = detectEventType(event);
-    if (!eventType) {
-      console.log(
-        "ERROR: event type not found in event\n",
-        JSON.stringify(event, null, 2)
-      );
-      continue;
-    }
-    if (!treeId) {
-      console.log(
-        "ERROR: treeId not found in event\n",
-        JSON.stringify(event, null, 2)
-      );
-      continue;
-    }
-    if (intermediateCompression[treeId] === undefined) {
-      intermediateCompression[treeId] = { nodes: {} };
-    }
-    switch (eventType) {
-      case "CREATE":
-        const createEvent = event as CreateEvent;
-        const createdNodeId = createEvent.id;
-        intermediateCompression[treeId]!.nodes[createdNodeId] = {
-          ...intermediateCompression[treeId]!.nodes[createdNodeId],
-          create: createEvent,
-          creationIndex: i,
-        };
-        break;
-      case "DELETE":
-        const deleteEvent = event as DeleteEvent;
-        const deletedNodeId = deleteEvent.id;
-        delete intermediateCompression[treeId]!.nodes[deletedNodeId];
-        break;
-      case "PATCH":
-        const patchEvent = event as PatchEvent;
-        const patchedNodeId = patchEvent.id;
-        if (intermediateCompression[treeId]!.nodes[patchedNodeId]?.patch) {
-          const currentPatchEvent =
-            intermediateCompression[treeId]!.nodes[patchedNodeId]!.patch!;
-          // mutating current patch event by merging with new patch event
-          mergeWith(
-            currentPatchEvent.slice,
-            patchEvent.slice,
-            mergeStateCustomizer
-          );
-        } else {
-          intermediateCompression[treeId]!.nodes[patchedNodeId] = {
-            ...intermediateCompression[treeId]!.nodes[patchedNodeId],
-            patch: patchEvent,
-          };
-        }
-        break;
-      case "LINK":
-        const linkEvent = event as LinkEvent;
-        const linkNodeId = linkEvent.childId;
-        intermediateCompression[treeId]!.nodes[linkNodeId] = {
-          ...intermediateCompression[treeId]!.nodes[linkNodeId],
-          link: linkEvent,
-          linkLast: true,
-        };
-        break;
-      case "UNLINK":
-        const unlinkEvent = event as UnlinkEvent;
-        const unlinkNodeId = unlinkEvent.childId;
-        intermediateCompression[treeId]!.nodes[unlinkNodeId] = {
-          ...intermediateCompression[treeId]!.nodes[unlinkNodeId],
-          unlink: unlinkEvent,
-          linkLast: false,
-        };
-        break;
-      default:
-        console.log(
-          "ERROR: unknown event type\n",
-          JSON.stringify(event, null, 2)
-        );
-        break;
-    }
+export function compressEvents(events: AnyEvent[], forestDef: ForestDef) {
+  if (forestDef.trees.length === 0) {
+    throw Error("Need atleas one tree in ForestDef");
   }
 
-  // flatten all trees
-  const allNodes = Object.keys(intermediateCompression)
+  const forest = createForest(forestDef);
+  forest.handleEvents({
+    name: "COMPRESSION",
+    events,
+    meta: { agent: "server-sent" },
+  });
+  const treeIds = forestDef.trees.map((treeDef) => {
+    return treeDef.id;
+  });
+
+  const rootTreeId = treeIds[0]!;
+  // root tree components
+  const rootTree = forest.tree(rootTreeId)!;
+  const rootTreeNodeMap = rootTree.nodes;
+  const rootTreeNodeIds = Object.keys(rootTreeNodeMap);
+
+  // process non root trees first
+  const nonRootTreeEvents = treeIds
+    .filter((treeId) => treeId !== rootTreeId)
     .map((treeId) => {
-      return Object.keys(intermediateCompression[treeId]!.nodes).map(
-        (nodeId) => {
-          return { ...intermediateCompression[treeId]!.nodes[nodeId]!, nodeId };
-        }
-      );
+      const tree = forest.tree(treeId)!;
+      const nodeMap = tree.nodes;
+      const linkRefIds = Object.keys(tree.links);
+      // keep only those nodes that are linked to root tree
+      const nodeIds = linkRefIds
+        .filter((refId) => {
+          return refId in rootTreeNodeMap;
+        })
+        .map((refId) => {
+          return tree.links[refId]!.childId;
+        });
+
+      const reverseLinkMap: { [childId: string]: string } = {};
+      linkRefIds.forEach((linkRefId) => {
+        return tree.links[linkRefId]!.childId;
+      });
+
+      return nodeIds.map((nodeId): AnyEvent[] => {
+        const node = nodeMap[nodeId]!;
+        return [
+          {
+            type: `CREATE$$${treeId}`,
+            id: nodeId,
+            meta: node.meta,
+            state: node.state,
+          },
+          {
+            type: `LINK$$${treeId}`,
+            childId: nodeId,
+            refId: reverseLinkMap[nodeId]!,
+          },
+        ];
+      });
     })
     .flat()
-    .filter((node) => {
-      return node.create !== undefined;
-    });
+    .flat();
 
-  // sort nodes based on their creation index
-  allNodes.sort((a, b) => {
-    return a.creationIndex! - b.creationIndex!;
+  const rootTreeEvents = rootTreeNodeIds.map((nodeId): AnyEvent => {
+    const node = rootTreeNodeMap[nodeId]!;
+    return {
+      type: `CREATE$$${rootTreeId}`,
+      id: nodeId,
+      meta: node.meta,
+      state: node.state,
+    };
   });
 
-  const newEvents: AnyEvent[] = [];
-  allNodes.forEach((node) => {
-    newEvents.push(node.create!);
-    if (node.patch) newEvents.push(node.patch);
-    if (node.linkLast !== undefined) {
-      switch (node.linkLast) {
-        case false:
-          if (node.unlink) newEvents.push(node.unlink!);
-          break;
-        default:
-          if (node.link) newEvents.push(node.link!);
-      }
-    }
-  });
-
-  return newEvents;
+  return [...nonRootTreeEvents, ...rootTreeEvents];
 }

--- a/packages/forest/src/forest.ts
+++ b/packages/forest/src/forest.ts
@@ -38,13 +38,6 @@ export function createForest(def: ForestDef): Forest {
     defaultFnMap[id] = def.defFn();
   });
 
-  const isRootTree = (treeId: string) => {
-    if (treeId === rootDef.modulePath) {
-      return true;
-    }
-    return false;
-  };
-
   // create an empty map of trees to be filled once API for forest is ready below
   const treeMap: { [treeId: string]: Tree } = {};
 
@@ -183,15 +176,6 @@ export function createForest(def: ForestDef): Forest {
         )
       );
       nodesToBeDeleted.reverse().forEach((nodeId) => {
-        // if event is from a root tree, call unlink on all child tree
-        if (isRootTree(treeId)) {
-          if (linkEvents[nodeId]) {
-            linkEvents[nodeId]!.forEach((event) => {
-              const unlinkEvent = { ...event, type: `UNLINK$$${treeId}` };
-              handleEvent(name, unlinkEvent, meta);
-            });
-          }
-        }
         const parentId = treeMap[treeId]!.nodes[nodeId]!.state.parent.id;
         const deletedNode = treeMap[treeId]!.nodes[nodeId]!;
         delete treeMap[treeId]!.nodes[nodeId];

--- a/packages/forest/src/tree.ts
+++ b/packages/forest/src/tree.ts
@@ -15,28 +15,28 @@ export function createTree(treeDef: TreeDef, forest: Forest) {
     patch: (event, meta) => {
       const patchEvent = {
         ...event,
-        type: `PATCH${eventSuffix}`,
+        type: `PATCH$$${eventSuffix}`,
       };
       forest.patch(patchEvent, meta);
     },
     del: (event, meta) => {
       const delEvent = {
         ...event,
-        type: `DELETE${eventSuffix}`,
+        type: `DELETE$$${eventSuffix}`,
       };
       forest.del(delEvent, meta);
     },
     link: (event, meta) => {
       const linkEvent = {
         ...event,
-        type: `LINK${eventSuffix}`,
+        type: `LINK$$${eventSuffix}`,
       };
       forest.link(linkEvent, meta);
     },
     unlink: (event, meta) => {
       const unlinkEvent = {
         ...event,
-        type: `UNLINK${eventSuffix}`,
+        type: `UNLINK$$${eventSuffix}`,
       };
       forest.link(unlinkEvent, meta);
     },

--- a/packages/forest/src/types.ts
+++ b/packages/forest/src/types.ts
@@ -68,12 +68,15 @@ export type LinkEvent = TreeLink & EventDto;
 
 export type UnlinkEvent = LinkEvent;
 
+export type HardPatchEvent = { id: string; state: any } & EventDto;
+
 export type AnyEvent =
   | CreateEvent
   | PatchEvent
   | DeleteEvent
   | LinkEvent
-  | UnlinkEvent;
+  | UnlinkEvent
+  | HardPatchEvent;
 
 export type TreeDefReturnType = {
   validateCreate: (event: CreateEvent) => boolean;

--- a/packages/server-client/src/utils/getForestDef.ts
+++ b/packages/server-client/src/utils/getForestDef.ts
@@ -1,0 +1,31 @@
+import { ToolConfig } from "@atrilabs/core";
+import { ForestDef, TreeDef } from "@atrilabs/forest";
+import { generateModuleId } from "@atrilabs/scripts";
+
+export function getForestDef(toolConfig: ToolConfig, appForestPkgId: string) {
+  // create tree def and forest def from toolConfig
+  const appForestEntry = toolConfig.forests[appForestPkgId];
+  if (appForestEntry === undefined) {
+    console.log(
+      `appForestPkgId not found in toolConfig\nappForestPkgId: ${appForestPkgId}\nforestConfigs: ${JSON.stringify(
+        toolConfig.forests,
+        null,
+        2
+      )}`
+    );
+    return;
+  }
+  const treeDefs: TreeDef[] = appForestEntry.map((treeDef) => {
+    return {
+      defFn: require(treeDef.modulePath).default,
+      id: generateModuleId(treeDef.modulePath),
+      modulePath: treeDef.modulePath,
+    };
+  });
+  const forestDef: ForestDef = {
+    id: appForestPkgId,
+    pkg: appForestPkgId,
+    trees: treeDefs,
+  };
+  return forestDef;
+}

--- a/packages/server-client/src/websocket/server.ts
+++ b/packages/server-client/src/websocket/server.ts
@@ -28,6 +28,7 @@ import {
   collectCreateTemplate,
   collectImportResources,
 } from "../utils/collect_stats";
+import { getForestDef } from "../utils/getForestDef";
 const app = express();
 const server = http.createServer(app);
 
@@ -123,6 +124,9 @@ export default function (toolConfig: ToolConfig, options: EventServerOptions) {
     getMeta(forestPkgId);
     getPages(forestPkgId);
   }
+
+  const target = toolConfig.targets[0]!;
+  const forestDef = getForestDef(toolConfig, target.options["appForestPkgId"])!;
 
   io.on("connection", (socket) => {
     socket.on("getMeta", (forestPkgId, callback) => {
@@ -285,7 +289,7 @@ export default function (toolConfig: ToolConfig, options: EventServerOptions) {
         initialLoadForest(forestPkgId);
         const eventManager = getEventManager(forestPkgId);
         const events = eventManager.fetchEvents(pageId);
-        const compressedEvents = compressEvents(events);
+        const compressedEvents = compressEvents(events, forestDef);
         callback(compressedEvents);
       } catch (err) {
         console.log(

--- a/packages/undo-redo-layer/src/hooks/useStoreUndoRedoEvents.ts
+++ b/packages/undo-redo-layer/src/hooks/useStoreUndoRedoEvents.ts
@@ -5,6 +5,7 @@ import {
   DeleteEvent,
   PatchEvent,
   TreeNode,
+  HardPatchEvent,
 } from "@atrilabs/forest";
 import { useCallback, useEffect } from "react";
 import ComponentTreeId from "@atrilabs/app-design-forest/lib/componentTree?id";
@@ -265,15 +266,15 @@ export const useStoreUndoRedoEvents = () => {
           // deleting parent from state to avoid error message in console
           delete oldState["parent"];
           delete newState["parent"];
-          const oldPatch: PatchEvent = {
-            type: `PATCH$$${treeId}`,
+          const oldPatch: HardPatchEvent = {
+            type: `HARDPATCH$$${treeId}`,
             id: nodeId,
-            slice: oldState,
+            state: oldState,
           };
-          const newPatch: PatchEvent = {
-            type: `PATCH$$${treeId}`,
+          const newPatch: HardPatchEvent = {
+            type: `HARDPATCH$$${treeId}`,
             id: nodeId,
-            slice: newState,
+            state: newState,
           };
           addToUndoQueue(forestPkgId, forestId, {
             undo: [oldPatch],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1021,7 +1021,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.17.12"
 
-"@babel/plugin-syntax-jsx@^7.18.6":
+"@babel/plugin-syntax-jsx@^7.18.6", "@babel/plugin-syntax-jsx@^7.7.2":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz#a8feef63b010150abd97f1649ec296e849943ca0"
   integrity sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==
@@ -2658,6 +2658,18 @@
     jest-util "^28.1.0"
     slash "^3.0.0"
 
+"@jest/console@^29.1.2":
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-29.1.2.tgz#0ae975a70004696f8320490fcaa1a4152f7b62e4"
+  integrity sha512-ujEBCcYs82BTmRxqfHMQggSlkUZP63AE5YEaTPj7eFyJOzukkTorstOUC7L6nE3w5SYadGVAnTsQ/ZjTGL0qYQ==
+  dependencies:
+    "@jest/types" "^29.1.2"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    jest-message-util "^29.1.2"
+    jest-util "^29.1.2"
+    slash "^3.0.0"
+
 "@jest/core@^28.1.0":
   version "28.1.0"
   resolved "https://registry.yarnpkg.com/@jest/core/-/core-28.1.0.tgz#784a1e6ce5358b46fcbdcfbbd93b1b713ed4ea80"
@@ -2693,6 +2705,40 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
+"@jest/core@^29.1.2":
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-29.1.2.tgz#e5ce7a71e7da45156a96fb5eeed11d18b67bd112"
+  integrity sha512-sCO2Va1gikvQU2ynDN8V4+6wB7iVrD2CvT0zaRst4rglf56yLly0NQ9nuRRAWFeimRf+tCdFsb1Vk1N9LrrMPA==
+  dependencies:
+    "@jest/console" "^29.1.2"
+    "@jest/reporters" "^29.1.2"
+    "@jest/test-result" "^29.1.2"
+    "@jest/transform" "^29.1.2"
+    "@jest/types" "^29.1.2"
+    "@types/node" "*"
+    ansi-escapes "^4.2.1"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.9"
+    jest-changed-files "^29.0.0"
+    jest-config "^29.1.2"
+    jest-haste-map "^29.1.2"
+    jest-message-util "^29.1.2"
+    jest-regex-util "^29.0.0"
+    jest-resolve "^29.1.2"
+    jest-resolve-dependencies "^29.1.2"
+    jest-runner "^29.1.2"
+    jest-runtime "^29.1.2"
+    jest-snapshot "^29.1.2"
+    jest-util "^29.1.2"
+    jest-validate "^29.1.2"
+    jest-watcher "^29.1.2"
+    micromatch "^4.0.4"
+    pretty-format "^29.1.2"
+    slash "^3.0.0"
+    strip-ansi "^6.0.0"
+
 "@jest/environment@^28.1.0":
   version "28.1.0"
   resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-28.1.0.tgz#dedf7d59ec341b9292fcf459fd0ed819eb2e228a"
@@ -2703,12 +2749,29 @@
     "@types/node" "*"
     jest-mock "^28.1.0"
 
+"@jest/environment@^29.1.2":
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-29.1.2.tgz#bb51a43fce9f960ba9a48f0b5b556f30618ebc0a"
+  integrity sha512-rG7xZ2UeOfvOVzoLIJ0ZmvPl4tBEQ2n73CZJSlzUjPw4or1oSWC0s0Rk0ZX+pIBJ04aVr6hLWFn1DFtrnf8MhQ==
+  dependencies:
+    "@jest/fake-timers" "^29.1.2"
+    "@jest/types" "^29.1.2"
+    "@types/node" "*"
+    jest-mock "^29.1.2"
+
 "@jest/expect-utils@^28.1.0":
   version "28.1.0"
   resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-28.1.0.tgz#a5cde811195515a9809b96748ae8bcc331a3538a"
   integrity sha512-5BrG48dpC0sB80wpeIX5FU6kolDJI4K0n5BM9a5V38MGx0pyRvUBSS0u2aNTdDzmOrCjhOg8pGs6a20ivYkdmw==
   dependencies:
     jest-get-type "^28.0.2"
+
+"@jest/expect-utils@^29.1.2":
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.1.2.tgz#66dbb514d38f7d21456bc774419c9ae5cca3f88d"
+  integrity sha512-4a48bhKfGj/KAH39u0ppzNTABXQ8QPccWAFUFobWBaEMSMp+sB31Z2fK/l47c4a/Mu1po2ffmfAIPxXbVTXdtg==
+  dependencies:
+    jest-get-type "^29.0.0"
 
 "@jest/expect@^28.1.0":
   version "28.1.0"
@@ -2717,6 +2780,14 @@
   dependencies:
     expect "^28.1.0"
     jest-snapshot "^28.1.0"
+
+"@jest/expect@^29.1.2":
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/@jest/expect/-/expect-29.1.2.tgz#334a86395f621f1ab63ad95b06a588b9114d7b7a"
+  integrity sha512-FXw/UmaZsyfRyvZw3M6POgSNqwmuOXJuzdNiMWW9LCYo0GRoRDhg+R5iq5higmRTHQY7hx32+j7WHwinRmoILQ==
+  dependencies:
+    expect "^29.1.2"
+    jest-snapshot "^29.1.2"
 
 "@jest/fake-timers@^28.1.0":
   version "28.1.0"
@@ -2730,6 +2801,18 @@
     jest-mock "^28.1.0"
     jest-util "^28.1.0"
 
+"@jest/fake-timers@^29.1.2":
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-29.1.2.tgz#f157cdf23b4da48ce46cb00fea28ed1b57fc271a"
+  integrity sha512-GppaEqS+QQYegedxVMpCe2xCXxxeYwQ7RsNx55zc8f+1q1qevkZGKequfTASI7ejmg9WwI+SJCrHe9X11bLL9Q==
+  dependencies:
+    "@jest/types" "^29.1.2"
+    "@sinonjs/fake-timers" "^9.1.2"
+    "@types/node" "*"
+    jest-message-util "^29.1.2"
+    jest-mock "^29.1.2"
+    jest-util "^29.1.2"
+
 "@jest/globals@^28.1.0":
   version "28.1.0"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-28.1.0.tgz#a4427d2eb11763002ff58e24de56b84ba79eb793"
@@ -2738,6 +2821,16 @@
     "@jest/environment" "^28.1.0"
     "@jest/expect" "^28.1.0"
     "@jest/types" "^28.1.0"
+
+"@jest/globals@^29.1.2":
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-29.1.2.tgz#826ede84bc280ae7f789cb72d325c48cd048b9d3"
+  integrity sha512-uMgfERpJYoQmykAd0ffyMq8wignN4SvLUG6orJQRe9WAlTRc9cdpCaE/29qurXixYJVZWUqIBXhSk8v5xN1V9g==
+  dependencies:
+    "@jest/environment" "^29.1.2"
+    "@jest/expect" "^29.1.2"
+    "@jest/types" "^29.1.2"
+    jest-mock "^29.1.2"
 
 "@jest/reporters@^28.1.0":
   version "28.1.0"
@@ -2769,6 +2862,37 @@
     terminal-link "^2.0.0"
     v8-to-istanbul "^9.0.0"
 
+"@jest/reporters@^29.1.2":
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-29.1.2.tgz#5520898ed0a4ecf69d8b671e1dc8465d0acdfa6e"
+  integrity sha512-X4fiwwyxy9mnfpxL0g9DD0KcTmEIqP0jUdnc2cfa9riHy+I6Gwwp5vOZiwyg0vZxfSDxrOlK9S4+340W4d+DAA==
+  dependencies:
+    "@bcoe/v8-coverage" "^0.2.3"
+    "@jest/console" "^29.1.2"
+    "@jest/test-result" "^29.1.2"
+    "@jest/transform" "^29.1.2"
+    "@jest/types" "^29.1.2"
+    "@jridgewell/trace-mapping" "^0.3.15"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    collect-v8-coverage "^1.0.0"
+    exit "^0.1.2"
+    glob "^7.1.3"
+    graceful-fs "^4.2.9"
+    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-instrument "^5.1.0"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^4.0.0"
+    istanbul-reports "^3.1.3"
+    jest-message-util "^29.1.2"
+    jest-util "^29.1.2"
+    jest-worker "^29.1.2"
+    slash "^3.0.0"
+    string-length "^4.0.1"
+    strip-ansi "^6.0.0"
+    terminal-link "^2.0.0"
+    v8-to-istanbul "^9.0.1"
+
 "@jest/schemas@^28.0.2":
   version "28.0.2"
   resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-28.0.2.tgz#08c30df6a8d07eafea0aef9fb222c5e26d72e613"
@@ -2776,12 +2900,28 @@
   dependencies:
     "@sinclair/typebox" "^0.23.3"
 
+"@jest/schemas@^29.0.0":
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.0.0.tgz#5f47f5994dd4ef067fb7b4188ceac45f77fe952a"
+  integrity sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==
+  dependencies:
+    "@sinclair/typebox" "^0.24.1"
+
 "@jest/source-map@^28.0.2":
   version "28.0.2"
   resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-28.0.2.tgz#914546f4410b67b1d42c262a1da7e0406b52dc90"
   integrity sha512-Y9dxC8ZpN3kImkk0LkK5XCEneYMAXlZ8m5bflmSL5vrwyeUpJfentacCUg6fOb8NOpOO7hz2+l37MV77T6BFPw==
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.7"
+    callsites "^3.0.0"
+    graceful-fs "^4.2.9"
+
+"@jest/source-map@^29.0.0":
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-29.0.0.tgz#f8d1518298089f8ae624e442bbb6eb870ee7783c"
+  integrity sha512-nOr+0EM8GiHf34mq2GcJyz/gYFyLQ2INDhAylrZJ9mMWoW21mLBfZa0BUVPPMxVYrLjeiRe2Z7kWXOGnS0TFhQ==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.15"
     callsites "^3.0.0"
     graceful-fs "^4.2.9"
 
@@ -2795,6 +2935,16 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
+"@jest/test-result@^29.1.2":
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-29.1.2.tgz#6a8d006eb2b31ce0287d1fc10d12b8ff8504f3c8"
+  integrity sha512-jjYYjjumCJjH9hHCoMhA8PCl1OxNeGgAoZ7yuGYILRJX9NjgzTN0pCT5qAoYR4jfOP8htIByvAlz9vfNSSBoVg==
+  dependencies:
+    "@jest/console" "^29.1.2"
+    "@jest/types" "^29.1.2"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    collect-v8-coverage "^1.0.0"
+
 "@jest/test-sequencer@^28.1.0":
   version "28.1.0"
   resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-28.1.0.tgz#ce7294bbe986415b9a30e218c7e705e6ebf2cdf2"
@@ -2803,6 +2953,16 @@
     "@jest/test-result" "^28.1.0"
     graceful-fs "^4.2.9"
     jest-haste-map "^28.1.0"
+    slash "^3.0.0"
+
+"@jest/test-sequencer@^29.1.2":
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-29.1.2.tgz#10bfd89c08bfdba382eb05cc79c1d23a01238a93"
+  integrity sha512-fU6dsUqqm8sA+cd85BmeF7Gu9DsXVWFdGn9taxM6xN1cKdcP/ivSgXh5QucFRFz1oZxKv3/9DYYbq0ULly3P/Q==
+  dependencies:
+    "@jest/test-result" "^29.1.2"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^29.1.2"
     slash "^3.0.0"
 
 "@jest/transform@^28.1.0":
@@ -2826,12 +2986,45 @@
     slash "^3.0.0"
     write-file-atomic "^4.0.1"
 
+"@jest/transform@^29.1.2":
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-29.1.2.tgz#20f814696e04f090421f6d505c14bbfe0157062a"
+  integrity sha512-2uaUuVHTitmkx1tHF+eBjb4p7UuzBG7SXIaA/hNIkaMP6K+gXYGxP38ZcrofzqN0HeZ7A90oqsOa97WU7WZkSw==
+  dependencies:
+    "@babel/core" "^7.11.6"
+    "@jest/types" "^29.1.2"
+    "@jridgewell/trace-mapping" "^0.3.15"
+    babel-plugin-istanbul "^6.1.1"
+    chalk "^4.0.0"
+    convert-source-map "^1.4.0"
+    fast-json-stable-stringify "^2.1.0"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^29.1.2"
+    jest-regex-util "^29.0.0"
+    jest-util "^29.1.2"
+    micromatch "^4.0.4"
+    pirates "^4.0.4"
+    slash "^3.0.0"
+    write-file-atomic "^4.0.1"
+
 "@jest/types@^28.1.0":
   version "28.1.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-28.1.0.tgz#508327a89976cbf9bd3e1cc74641a29fd7dfd519"
   integrity sha512-xmEggMPr317MIOjjDoZ4ejCSr9Lpbt/u34+dvc99t7DS8YirW5rwZEhzKPC2BMUFkUhI48qs6qLUSGw5FuL0GA==
   dependencies:
     "@jest/schemas" "^28.0.2"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.8"
+    chalk "^4.0.0"
+
+"@jest/types@^29.1.2":
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.1.2.tgz#7442d32b16bcd7592d9614173078b8c334ec730a"
+  integrity sha512-DcXGtoTykQB5jiwCmVr8H4vdg2OJhQex3qPkG+ISyDO7xQXbt/4R6dowcRyPemRnkH7JoHvZuxPBdlq+9JxFCg==
+  dependencies:
+    "@jest/schemas" "^29.0.0"
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
@@ -2855,7 +3048,7 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/resolve-uri@^3.0.3":
+"@jridgewell/resolve-uri@3.1.0", "@jridgewell/resolve-uri@^3.0.3":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
   integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
@@ -2878,7 +3071,7 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/sourcemap-codec@^1.4.10":
+"@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10":
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
@@ -2890,6 +3083,14 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.15":
+  version "0.3.16"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.16.tgz#a7982f16c18cae02be36274365433e5b49d7b23f"
+  integrity sha512-LCQ+NeThyJ4k1W2d+vIKdxuSt9R3pQSZ4P92m7EakaYuXcVWbHuT5bjNcqLd4Rdgi6xYWYDvBJZJLZSLanjDcA==
+  dependencies:
+    "@jridgewell/resolve-uri" "3.1.0"
+    "@jridgewell/sourcemap-codec" "1.4.14"
 
 "@jridgewell/trace-mapping@^0.3.7", "@jridgewell/trace-mapping@^0.3.8":
   version "0.3.13"
@@ -4021,6 +4222,11 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.23.5.tgz#93f7b9f4e3285a7a9ade7557d9a8d36809cbc47d"
   integrity sha512-AFBVi/iT4g20DHoujvMH1aEDn8fGJh4xsRGCP6d8RpLPMqsNPvW01Jcn0QysXTsg++/xj25NmJsGyH9xug/wKg==
 
+"@sinclair/typebox@^0.24.1":
+  version "0.24.44"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.44.tgz#0a0aa3bf4a155a678418527342a3ee84bd8caa5c"
+  integrity sha512-ka0W0KN5i6LfrSocduwliMMpqVgohtPFidKdMEOUjoOFCHcOOYkKsPRxfs5f15oPNHTm6ERAm0GV/+/LTKeiWg==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -4028,7 +4234,7 @@
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/fake-timers@^9.1.1":
+"@sinonjs/fake-timers@^9.1.1", "@sinonjs/fake-timers@^9.1.2":
   version "9.1.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz#4eaab737fab77332ab132d396a3c0d364bd0ea8c"
   integrity sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==
@@ -4381,6 +4587,14 @@
   integrity sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==
   dependencies:
     "@types/istanbul-lib-report" "*"
+
+"@types/jest@^29.1.2":
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.1.2.tgz#7ad8077043ab5f6c108c8111bcc1d224e5600a87"
+  integrity sha512-y+nlX0h87U0R+wsGn6EBuoRWYyv3KFtwRNP3QWp9+k2tJ2/bqcGS3UxD7jgT+tiwJWWq3UsyV4Y+T6rsMT4XMg==
+  dependencies:
+    expect "^29.0.0"
+    pretty-format "^29.0.0"
 
 "@types/joi@^17.2.3":
   version "17.2.3"
@@ -5311,6 +5525,19 @@ babel-jest@^28.1.0:
     graceful-fs "^4.2.9"
     slash "^3.0.0"
 
+babel-jest@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.1.2.tgz#540d3241925c55240fb0c742e3ffc5f33a501978"
+  integrity sha512-IuG+F3HTHryJb7gacC7SQ59A9kO56BctUsT67uJHp1mMCHUOMXpDwOHWGifWqdWVknN2WNkCVQELPjXx0aLJ9Q==
+  dependencies:
+    "@jest/transform" "^29.1.2"
+    "@types/babel__core" "^7.1.14"
+    babel-plugin-istanbul "^6.1.1"
+    babel-preset-jest "^29.0.2"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    slash "^3.0.0"
+
 babel-loader@^8.2.4:
   version "8.2.4"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.2.4.tgz#95f5023c791b2e9e2ca6f67b0984f39c82ff384b"
@@ -5353,6 +5580,16 @@ babel-plugin-jest-hoist@^28.0.2:
   version "28.0.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-28.0.2.tgz#9307d03a633be6fc4b1a6bc5c3a87e22bd01dd3b"
   integrity sha512-Kizhn/ZL+68ZQHxSnHyuvJv8IchXD62KQxV77TBDV/xoBFBOfgRAk97GNs6hXdTTCiVES9nB2I6+7MXXrk5llQ==
+  dependencies:
+    "@babel/template" "^7.3.3"
+    "@babel/types" "^7.3.3"
+    "@types/babel__core" "^7.1.14"
+    "@types/babel__traverse" "^7.0.6"
+
+babel-plugin-jest-hoist@^29.0.2:
+  version "29.0.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.0.2.tgz#ae61483a829a021b146c016c6ad39b8bcc37c2c8"
+  integrity sha512-eBr2ynAEFjcebVvu8Ktx580BD1QKCrBG1XwEUTXJe285p9HA/4hOhfWCFRQhTKSyBV0VzjhG7H91Eifz9s29hg==
   dependencies:
     "@babel/template" "^7.3.3"
     "@babel/types" "^7.3.3"
@@ -5431,6 +5668,14 @@ babel-preset-jest@^28.0.2:
   integrity sha512-sYzXIdgIXXroJTFeB3S6sNDWtlJ2dllCdTEsnZ65ACrMojj3hVNFRmnJ1HZtomGi+Be7aqpY/HJ92fr8OhKVkQ==
   dependencies:
     babel-plugin-jest-hoist "^28.0.2"
+    babel-preset-current-node-syntax "^1.0.0"
+
+babel-preset-jest@^29.0.2:
+  version "29.0.2"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-29.0.2.tgz#e14a7124e22b161551818d89e5bdcfb3b2b0eac7"
+  integrity sha512-BeVXp7rH5TK96ofyEnHjznjLMQ2nAeDJ+QzxKnHAAMs0RgrQsCywjAN8m4mOm5Di0pxU//3AoEeJJrerMH5UeA==
+  dependencies:
+    babel-plugin-jest-hoist "^29.0.2"
     babel-preset-current-node-syntax "^1.0.0"
 
 babel-preset-react-app@^10.0.1:
@@ -5615,6 +5860,13 @@ browserslist@^4.20.2, browserslist@^4.20.3:
     escalade "^3.1.1"
     node-releases "^2.0.3"
     picocolors "^1.0.0"
+
+bs-logger@0.x:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
 
 bser@2.1.1:
   version "2.1.1"
@@ -6683,6 +6935,11 @@ diff-sequences@^28.0.2:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-28.0.2.tgz#40f8d4ffa081acbd8902ba35c798458d0ff1af41"
   integrity sha512-YtEoNynLDFCRznv/XDalsKGSZDoj0U5kLnXvY0JSq3nBboRrZXjD81+eSiwi+nzcZDwedMmcowcxNwwgFW23mQ==
 
+diff-sequences@^29.0.0:
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.0.0.tgz#bae49972ef3933556bcb0800b72e8579d19d9e4f"
+  integrity sha512-7Qe/zd1wxSDL4D/X/FPjOMB+ZMDt71W94KYaq05I2l0oQqgXgs7s4ftYYmV38gBSrPz2vcygxfs1xn0FT+rKNA==
+
 diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
@@ -7420,6 +7677,17 @@ expect@^28.1.0:
     jest-message-util "^28.1.0"
     jest-util "^28.1.0"
 
+expect@^29.0.0, expect@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-29.1.2.tgz#82f8f28d7d408c7c68da3a386a490ee683e1eced"
+  integrity sha512-AuAGn1uxva5YBbBlXb+2JPxJRuemZsmlGcapPXWNSBNsQtAULfjioREGBWuI0EOvYUKjDnrCy8PW5Zlr1md5mw==
+  dependencies:
+    "@jest/expect-utils" "^29.1.2"
+    jest-get-type "^29.0.0"
+    jest-matcher-utils "^29.1.2"
+    jest-message-util "^29.1.2"
+    jest-util "^29.1.2"
+
 express@^4.17.3:
   version "4.17.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.3.tgz#f6c7302194a4fb54271b73a1fe7a06478c8f85a1"
@@ -7541,7 +7809,7 @@ fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -8866,6 +9134,14 @@ jest-changed-files@^28.0.2:
     execa "^5.0.0"
     throat "^6.0.1"
 
+jest-changed-files@^29.0.0:
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-29.0.0.tgz#aa238eae42d9372a413dd9a8dadc91ca1806dce0"
+  integrity sha512-28/iDMDrUpGoCitTURuDqUzWQoWmOmOKOFST1mi2lwh62X4BFf6khgH3uSuo1e49X/UDjuApAj3w0wLOex4VPQ==
+  dependencies:
+    execa "^5.0.0"
+    p-limit "^3.1.0"
+
 jest-circus@^28.1.0:
   version "28.1.0"
   resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-28.1.0.tgz#e229f590911bd54d60efaf076f7acd9360296dae"
@@ -8891,6 +9167,31 @@ jest-circus@^28.1.0:
     stack-utils "^2.0.3"
     throat "^6.0.1"
 
+jest-circus@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-29.1.2.tgz#4551068e432f169a53167fe1aef420cf51c8a735"
+  integrity sha512-ajQOdxY6mT9GtnfJRZBRYS7toNIJayiiyjDyoZcnvPRUPwJ58JX0ci0PKAKUo2C1RyzlHw0jabjLGKksO42JGA==
+  dependencies:
+    "@jest/environment" "^29.1.2"
+    "@jest/expect" "^29.1.2"
+    "@jest/test-result" "^29.1.2"
+    "@jest/types" "^29.1.2"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    co "^4.6.0"
+    dedent "^0.7.0"
+    is-generator-fn "^2.0.0"
+    jest-each "^29.1.2"
+    jest-matcher-utils "^29.1.2"
+    jest-message-util "^29.1.2"
+    jest-runtime "^29.1.2"
+    jest-snapshot "^29.1.2"
+    jest-util "^29.1.2"
+    p-limit "^3.1.0"
+    pretty-format "^29.1.2"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
 jest-cli@^28.1.0:
   version "28.1.0"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-28.1.0.tgz#cd1d8adb9630102d5ba04a22895f63decdd7ac1f"
@@ -8906,6 +9207,24 @@ jest-cli@^28.1.0:
     jest-config "^28.1.0"
     jest-util "^28.1.0"
     jest-validate "^28.1.0"
+    prompts "^2.0.1"
+    yargs "^17.3.1"
+
+jest-cli@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-29.1.2.tgz#423b9c5d3ea20a50b1354b8bf3f2a20e72110e89"
+  integrity sha512-vsvBfQ7oS2o4MJdAH+4u9z76Vw5Q8WBQF5MchDbkylNknZdrPTX1Ix7YRJyTlOWqRaS7ue/cEAn+E4V1MWyMzw==
+  dependencies:
+    "@jest/core" "^29.1.2"
+    "@jest/test-result" "^29.1.2"
+    "@jest/types" "^29.1.2"
+    chalk "^4.0.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.9"
+    import-local "^3.0.2"
+    jest-config "^29.1.2"
+    jest-util "^29.1.2"
+    jest-validate "^29.1.2"
     prompts "^2.0.1"
     yargs "^17.3.1"
 
@@ -8937,6 +9256,34 @@ jest-config@^28.1.0:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
+jest-config@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-29.1.2.tgz#7d004345ca4c09f5d8f802355f54494e90842f4d"
+  integrity sha512-EC3Zi86HJUOz+2YWQcJYQXlf0zuBhJoeyxLM6vb6qJsVmpP7KcCP1JnyF0iaqTaXdBP8Rlwsvs7hnKWQWWLwwA==
+  dependencies:
+    "@babel/core" "^7.11.6"
+    "@jest/test-sequencer" "^29.1.2"
+    "@jest/types" "^29.1.2"
+    babel-jest "^29.1.2"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    deepmerge "^4.2.2"
+    glob "^7.1.3"
+    graceful-fs "^4.2.9"
+    jest-circus "^29.1.2"
+    jest-environment-node "^29.1.2"
+    jest-get-type "^29.0.0"
+    jest-regex-util "^29.0.0"
+    jest-resolve "^29.1.2"
+    jest-runner "^29.1.2"
+    jest-util "^29.1.2"
+    jest-validate "^29.1.2"
+    micromatch "^4.0.4"
+    parse-json "^5.2.0"
+    pretty-format "^29.1.2"
+    slash "^3.0.0"
+    strip-json-comments "^3.1.1"
+
 jest-diff@^28.1.0:
   version "28.1.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-28.1.0.tgz#77686fef899ec1873dbfbf9330e37dd429703269"
@@ -8947,10 +9294,27 @@ jest-diff@^28.1.0:
     jest-get-type "^28.0.2"
     pretty-format "^28.1.0"
 
+jest-diff@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.1.2.tgz#bb7aaf5353227d6f4f96c5e7e8713ce576a607dc"
+  integrity sha512-4GQts0aUopVvecIT4IwD/7xsBaMhKTYoM4/njE/aVw9wpw+pIUVp8Vab/KnSzSilr84GnLBkaP3JLDnQYCKqVQ==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^29.0.0"
+    jest-get-type "^29.0.0"
+    pretty-format "^29.1.2"
+
 jest-docblock@^28.0.2:
   version "28.0.2"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-28.0.2.tgz#3cab8abea53275c9d670cdca814fc89fba1298c2"
   integrity sha512-FH10WWw5NxLoeSdQlJwu+MTiv60aXV/t8KEwIRGEv74WARE1cXIqh1vGdy2CraHuWOOrnzTWj/azQKqW4fO7xg==
+  dependencies:
+    detect-newline "^3.0.0"
+
+jest-docblock@^29.0.0:
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-29.0.0.tgz#3151bcc45ed7f5a8af4884dcc049aee699b4ceae"
+  integrity sha512-s5Kpra/kLzbqu9dEjov30kj1n4tfu3e7Pl8v+f8jOkeWNqM6Ds8jRaJfZow3ducoQUrf2Z4rs2N5S3zXnb83gw==
   dependencies:
     detect-newline "^3.0.0"
 
@@ -8965,6 +9329,17 @@ jest-each@^28.1.0:
     jest-util "^28.1.0"
     pretty-format "^28.1.0"
 
+jest-each@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-29.1.2.tgz#d4c8532c07a846e79f194f7007ce7cb1987d1cd0"
+  integrity sha512-AmTQp9b2etNeEwMyr4jc0Ql/LIX/dhbgP21gHAizya2X6rUspHn2gysMXaj6iwWuOJ2sYRgP8c1P4cXswgvS1A==
+  dependencies:
+    "@jest/types" "^29.1.2"
+    chalk "^4.0.0"
+    jest-get-type "^29.0.0"
+    jest-util "^29.1.2"
+    pretty-format "^29.1.2"
+
 jest-environment-node@^28.1.0:
   version "28.1.0"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-28.1.0.tgz#6ed2150aa31babba0c488c5b4f4d813a585c68e6"
@@ -8977,10 +9352,27 @@ jest-environment-node@^28.1.0:
     jest-mock "^28.1.0"
     jest-util "^28.1.0"
 
+jest-environment-node@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-29.1.2.tgz#005e05cc6ea4b9b5ba55906ab1ce53c82f6907a7"
+  integrity sha512-C59yVbdpY8682u6k/lh8SUMDJPbOyCHOTgLVVi1USWFxtNV+J8fyIwzkg+RJIVI30EKhKiAGNxYaFr3z6eyNhQ==
+  dependencies:
+    "@jest/environment" "^29.1.2"
+    "@jest/fake-timers" "^29.1.2"
+    "@jest/types" "^29.1.2"
+    "@types/node" "*"
+    jest-mock "^29.1.2"
+    jest-util "^29.1.2"
+
 jest-get-type@^28.0.2:
   version "28.0.2"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-28.0.2.tgz#34622e628e4fdcd793d46db8a242227901fcf203"
   integrity sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==
+
+jest-get-type@^29.0.0:
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.0.0.tgz#843f6c50a1b778f7325df1129a0fd7aa713aef80"
+  integrity sha512-83X19z/HuLKYXYHskZlBAShO7UfLFXu/vWajw9ZNJASN32li8yHMaVGAQqxFW1RCFOkB7cubaL6FaJVQqqJLSw==
 
 jest-haste-map@^28.1.0:
   version "28.1.0"
@@ -9001,6 +9393,25 @@ jest-haste-map@^28.1.0:
   optionalDependencies:
     fsevents "^2.3.2"
 
+jest-haste-map@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-29.1.2.tgz#93f3634aa921b6b654e7c94137b24e02e7ca6ac9"
+  integrity sha512-xSjbY8/BF11Jh3hGSPfYTa/qBFrm3TPM7WU8pU93m2gqzORVLkHFWvuZmFsTEBPRKndfewXhMOuzJNHyJIZGsw==
+  dependencies:
+    "@jest/types" "^29.1.2"
+    "@types/graceful-fs" "^4.1.3"
+    "@types/node" "*"
+    anymatch "^3.0.3"
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.2.9"
+    jest-regex-util "^29.0.0"
+    jest-util "^29.1.2"
+    jest-worker "^29.1.2"
+    micromatch "^4.0.4"
+    walker "^1.0.8"
+  optionalDependencies:
+    fsevents "^2.3.2"
+
 jest-leak-detector@^28.1.0:
   version "28.1.0"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-28.1.0.tgz#b65167776a8787443214d6f3f54935a4c73c8a45"
@@ -9008,6 +9419,14 @@ jest-leak-detector@^28.1.0:
   dependencies:
     jest-get-type "^28.0.2"
     pretty-format "^28.1.0"
+
+jest-leak-detector@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-29.1.2.tgz#4c846db14c58219430ccbc4f01a1ec52ebee4fc2"
+  integrity sha512-TG5gAZJpgmZtjb6oWxBLf2N6CfQ73iwCe6cofu/Uqv9iiAm6g502CAnGtxQaTfpHECBdVEMRBhomSXeLnoKjiQ==
+  dependencies:
+    jest-get-type "^29.0.0"
+    pretty-format "^29.1.2"
 
 jest-matcher-utils@^28.1.0:
   version "28.1.0"
@@ -9018,6 +9437,16 @@ jest-matcher-utils@^28.1.0:
     jest-diff "^28.1.0"
     jest-get-type "^28.0.2"
     pretty-format "^28.1.0"
+
+jest-matcher-utils@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.1.2.tgz#e68c4bcc0266e70aa1a5c13fb7b8cd4695e318a1"
+  integrity sha512-MV5XrD3qYSW2zZSHRRceFzqJ39B2z11Qv0KPyZYxnzDHFeYZGJlgGi0SW+IXSJfOewgJp/Km/7lpcFT+cgZypw==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^29.1.2"
+    jest-get-type "^29.0.0"
+    pretty-format "^29.1.2"
 
 jest-message-util@^28.1.0:
   version "28.1.0"
@@ -9034,6 +9463,21 @@ jest-message-util@^28.1.0:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
+jest-message-util@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.1.2.tgz#c21a33c25f9dc1ebfcd0f921d89438847a09a501"
+  integrity sha512-9oJ2Os+Qh6IlxLpmvshVbGUiSkZVc2FK+uGOm6tghafnB2RyjKAxMZhtxThRMxfX1J1SOMhTn9oK3/MutRWQJQ==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@jest/types" "^29.1.2"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    micromatch "^4.0.4"
+    pretty-format "^29.1.2"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
 jest-mock@^28.1.0:
   version "28.1.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-28.1.0.tgz#ccc7cc12a9b330b3182db0c651edc90d163ff73e"
@@ -9041,6 +9485,15 @@ jest-mock@^28.1.0:
   dependencies:
     "@jest/types" "^28.1.0"
     "@types/node" "*"
+
+jest-mock@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.1.2.tgz#de47807edbb9d4abf8423f1d8d308d670105678c"
+  integrity sha512-PFDAdjjWbjPUtQPkQufvniXIS3N9Tv7tbibePEjIIprzjgo0qQlyUiVMrT4vL8FaSJo1QXifQUOuPH3HQC/aMA==
+  dependencies:
+    "@jest/types" "^29.1.2"
+    "@types/node" "*"
+    jest-util "^29.1.2"
 
 jest-pnp-resolver@^1.2.2:
   version "1.2.2"
@@ -9052,6 +9505,11 @@ jest-regex-util@^28.0.2:
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-28.0.2.tgz#afdc377a3b25fb6e80825adcf76c854e5bf47ead"
   integrity sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==
 
+jest-regex-util@^29.0.0:
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-29.0.0.tgz#b442987f688289df8eb6c16fa8df488b4cd007de"
+  integrity sha512-BV7VW7Sy0fInHWN93MMPtlClweYv2qrSCwfeFWmpribGZtQPWNvRSq9XOVgOEjU1iBGRKXUZil0o2AH7Iy9Lug==
+
 jest-resolve-dependencies@^28.1.0:
   version "28.1.0"
   resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-28.1.0.tgz#167becb8bee6e20b5ef4a3a728ec67aef6b0b79b"
@@ -9059,6 +9517,14 @@ jest-resolve-dependencies@^28.1.0:
   dependencies:
     jest-regex-util "^28.0.2"
     jest-snapshot "^28.1.0"
+
+jest-resolve-dependencies@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-29.1.2.tgz#a6919e58a0c7465582cb8ec2d745b4e64ae8647f"
+  integrity sha512-44yYi+yHqNmH3OoWZvPgmeeiwKxhKV/0CfrzaKLSkZG9gT973PX8i+m8j6pDrTYhhHoiKfF3YUFg/6AeuHw4HQ==
+  dependencies:
+    jest-regex-util "^29.0.0"
+    jest-snapshot "^29.1.2"
 
 jest-resolve@^28.1.0:
   version "28.1.0"
@@ -9071,6 +9537,21 @@ jest-resolve@^28.1.0:
     jest-pnp-resolver "^1.2.2"
     jest-util "^28.1.0"
     jest-validate "^28.1.0"
+    resolve "^1.20.0"
+    resolve.exports "^1.1.0"
+    slash "^3.0.0"
+
+jest-resolve@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-29.1.2.tgz#9dd8c2fc83e59ee7d676b14bd45a5f89e877741d"
+  integrity sha512-7fcOr+k7UYSVRJYhSmJHIid3AnDBcLQX3VmT9OSbPWsWz1MfT7bcoerMhADKGvKCoMpOHUQaDHtQoNp/P9JMGg==
+  dependencies:
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^29.1.2"
+    jest-pnp-resolver "^1.2.2"
+    jest-util "^29.1.2"
+    jest-validate "^29.1.2"
     resolve "^1.20.0"
     resolve.exports "^1.1.0"
     slash "^3.0.0"
@@ -9102,6 +9583,33 @@ jest-runner@^28.1.0:
     source-map-support "0.5.13"
     throat "^6.0.1"
 
+jest-runner@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-29.1.2.tgz#f18b2b86101341e047de8c2f51a5fdc4e97d053a"
+  integrity sha512-yy3LEWw8KuBCmg7sCGDIqKwJlULBuNIQa2eFSVgVASWdXbMYZ9H/X0tnXt70XFoGf92W2sOQDOIFAA6f2BG04Q==
+  dependencies:
+    "@jest/console" "^29.1.2"
+    "@jest/environment" "^29.1.2"
+    "@jest/test-result" "^29.1.2"
+    "@jest/transform" "^29.1.2"
+    "@jest/types" "^29.1.2"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    emittery "^0.10.2"
+    graceful-fs "^4.2.9"
+    jest-docblock "^29.0.0"
+    jest-environment-node "^29.1.2"
+    jest-haste-map "^29.1.2"
+    jest-leak-detector "^29.1.2"
+    jest-message-util "^29.1.2"
+    jest-resolve "^29.1.2"
+    jest-runtime "^29.1.2"
+    jest-util "^29.1.2"
+    jest-watcher "^29.1.2"
+    jest-worker "^29.1.2"
+    p-limit "^3.1.0"
+    source-map-support "0.5.13"
+
 jest-runtime@^28.1.0:
   version "28.1.0"
   resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-28.1.0.tgz#4847dcb2a4eb4b0f9eaf41306897e51fb1665631"
@@ -9127,6 +9635,34 @@ jest-runtime@^28.1.0:
     jest-resolve "^28.1.0"
     jest-snapshot "^28.1.0"
     jest-util "^28.1.0"
+    slash "^3.0.0"
+    strip-bom "^4.0.0"
+
+jest-runtime@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-29.1.2.tgz#dbcd57103d61115479108d5864bdcd661d9c6783"
+  integrity sha512-jr8VJLIf+cYc+8hbrpt412n5jX3tiXmpPSYTGnwcvNemY+EOuLNiYnHJ3Kp25rkaAcTWOEI4ZdOIQcwYcXIAZw==
+  dependencies:
+    "@jest/environment" "^29.1.2"
+    "@jest/fake-timers" "^29.1.2"
+    "@jest/globals" "^29.1.2"
+    "@jest/source-map" "^29.0.0"
+    "@jest/test-result" "^29.1.2"
+    "@jest/transform" "^29.1.2"
+    "@jest/types" "^29.1.2"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    cjs-module-lexer "^1.0.0"
+    collect-v8-coverage "^1.0.0"
+    glob "^7.1.3"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^29.1.2"
+    jest-message-util "^29.1.2"
+    jest-mock "^29.1.2"
+    jest-regex-util "^29.0.0"
+    jest-resolve "^29.1.2"
+    jest-snapshot "^29.1.2"
+    jest-util "^29.1.2"
     slash "^3.0.0"
     strip-bom "^4.0.0"
 
@@ -9159,12 +9695,54 @@ jest-snapshot@^28.1.0:
     pretty-format "^28.1.0"
     semver "^7.3.5"
 
+jest-snapshot@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-29.1.2.tgz#7dd277e88c45f2d2ff5888de1612e63c7ceb575b"
+  integrity sha512-rYFomGpVMdBlfwTYxkUp3sjD6usptvZcONFYNqVlaz4EpHPnDvlWjvmOQ9OCSNKqYZqLM2aS3wq01tWujLg7gg==
+  dependencies:
+    "@babel/core" "^7.11.6"
+    "@babel/generator" "^7.7.2"
+    "@babel/plugin-syntax-jsx" "^7.7.2"
+    "@babel/plugin-syntax-typescript" "^7.7.2"
+    "@babel/traverse" "^7.7.2"
+    "@babel/types" "^7.3.3"
+    "@jest/expect-utils" "^29.1.2"
+    "@jest/transform" "^29.1.2"
+    "@jest/types" "^29.1.2"
+    "@types/babel__traverse" "^7.0.6"
+    "@types/prettier" "^2.1.5"
+    babel-preset-current-node-syntax "^1.0.0"
+    chalk "^4.0.0"
+    expect "^29.1.2"
+    graceful-fs "^4.2.9"
+    jest-diff "^29.1.2"
+    jest-get-type "^29.0.0"
+    jest-haste-map "^29.1.2"
+    jest-matcher-utils "^29.1.2"
+    jest-message-util "^29.1.2"
+    jest-util "^29.1.2"
+    natural-compare "^1.4.0"
+    pretty-format "^29.1.2"
+    semver "^7.3.5"
+
 jest-util@^28.1.0:
   version "28.1.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-28.1.0.tgz#d54eb83ad77e1dd441408738c5a5043642823be5"
   integrity sha512-qYdCKD77k4Hwkose2YBEqQk7PzUf/NSE+rutzceduFveQREeH6b+89Dc9+wjX9dAwHcgdx4yedGA3FQlU/qCTA==
   dependencies:
     "@jest/types" "^28.1.0"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.9"
+    picomatch "^2.2.3"
+
+jest-util@^29.0.0, jest-util@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.1.2.tgz#ac5798e93cb6a6703084e194cfa0898d66126df1"
+  integrity sha512-vPCk9F353i0Ymx3WQq3+a4lZ07NXu9Ca8wya6o4Fe4/aO1e1awMMprZ3woPFpKwghEOW+UXgd15vVotuNN9ONQ==
+  dependencies:
+    "@jest/types" "^29.1.2"
     "@types/node" "*"
     chalk "^4.0.0"
     ci-info "^3.2.0"
@@ -9183,6 +9761,18 @@ jest-validate@^28.1.0:
     leven "^3.1.0"
     pretty-format "^28.1.0"
 
+jest-validate@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-29.1.2.tgz#83a728b8f6354da2e52346878c8bc7383516ca51"
+  integrity sha512-k71pOslNlV8fVyI+mEySy2pq9KdXdgZtm7NHrBX8LghJayc3wWZH0Yr0mtYNGaCU4F1OLPXRkwZR0dBm/ClshA==
+  dependencies:
+    "@jest/types" "^29.1.2"
+    camelcase "^6.2.0"
+    chalk "^4.0.0"
+    jest-get-type "^29.0.0"
+    leven "^3.1.0"
+    pretty-format "^29.1.2"
+
 jest-watcher@^28.1.0:
   version "28.1.0"
   resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-28.1.0.tgz#aaa7b4164a4e77eeb5f7d7b25ede5e7b4e9c9aaf"
@@ -9195,6 +9785,20 @@ jest-watcher@^28.1.0:
     chalk "^4.0.0"
     emittery "^0.10.2"
     jest-util "^28.1.0"
+    string-length "^4.0.1"
+
+jest-watcher@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-29.1.2.tgz#de21439b7d889e2fcf62cc2a4779ef1a3f1f3c62"
+  integrity sha512-6JUIUKVdAvcxC6bM8/dMgqY2N4lbT+jZVsxh0hCJRbwkIEnbr/aPjMQ28fNDI5lB51Klh00MWZZeVf27KBUj5w==
+  dependencies:
+    "@jest/test-result" "^29.1.2"
+    "@jest/types" "^29.1.2"
+    "@types/node" "*"
+    ansi-escapes "^4.2.1"
+    chalk "^4.0.0"
+    emittery "^0.10.2"
+    jest-util "^29.1.2"
     string-length "^4.0.1"
 
 jest-worker@^27.4.5:
@@ -9215,6 +9819,16 @@ jest-worker@^28.1.0:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
+jest-worker@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-29.1.2.tgz#a68302af61bce82b42a9a57285ca7499d29b2afc"
+  integrity sha512-AdTZJxKjTSPHbXT/AIOjQVmoFx0LHFcVabWu0sxI7PAy7rFf8c0upyvgBKgguVXdM4vY74JdwkyD4hSmpTW8jA==
+  dependencies:
+    "@types/node" "*"
+    jest-util "^29.1.2"
+    merge-stream "^2.0.0"
+    supports-color "^8.0.0"
+
 jest@^28.1.0:
   version "28.1.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-28.1.0.tgz#f420e41c8f2395b9a30445a97189ebb57593d831"
@@ -9223,6 +9837,16 @@ jest@^28.1.0:
     "@jest/core" "^28.1.0"
     import-local "^3.0.2"
     jest-cli "^28.1.0"
+
+jest@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-29.1.2.tgz#f821a1695ffd6cd0efc3b59d2dfcc70a98582499"
+  integrity sha512-5wEIPpCezgORnqf+rCaYD1SK+mNN7NsstWzIsuvsnrhR/hSxXWd82oI7DkrbJ+XTD28/eG8SmxdGvukrGGK6Tw==
+  dependencies:
+    "@jest/core" "^29.1.2"
+    "@jest/types" "^29.1.2"
+    import-local "^3.0.2"
+    jest-cli "^29.1.2"
 
 joi@*, joi@^17.6.0:
   version "17.6.0"
@@ -9560,6 +10184,11 @@ lodash.ismatch@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
   integrity sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==
 
+lodash.memoize@4.x:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -9635,7 +10264,7 @@ make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@^1.1.1:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -10475,7 +11104,7 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.2:
+p-limit@^3.0.2, p-limit@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
@@ -11318,6 +11947,15 @@ pretty-format@^28.1.0:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
+pretty-format@^29.0.0, pretty-format@^29.1.2:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.1.2.tgz#b1f6b75be7d699be1a051f5da36e8ae9e76a8e6a"
+  integrity sha512-CGJ6VVGXVRP2o2Dorl4mAwwvDWT25luIsYhkyVQW32E4nL+TgW939J7LlKT/npq5Cpq6j3s+sy+13yk7xYpBmg==
+  dependencies:
+    "@jest/schemas" "^29.0.0"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
 proc-log@^2.0.0, proc-log@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/proc-log/-/proc-log-2.0.1.tgz#8f3f69a1f608de27878f91f5c688b225391cb685"
@@ -12131,6 +12769,13 @@ semver@7.3.4:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@7.x:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -13007,6 +13652,20 @@ trim-newlines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
+ts-jest@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.0.3.tgz#63ea93c5401ab73595440733cefdba31fcf9cb77"
+  integrity sha512-Ibygvmuyq1qp/z3yTh9QTwVVAbFdDy/+4BtIQR2sp6baF2SJU/8CKK/hhnGIDY2L90Az2jIqTwZPnN2p+BweiQ==
+  dependencies:
+    bs-logger "0.x"
+    fast-json-stable-stringify "2.x"
+    jest-util "^29.0.0"
+    json5 "^2.2.1"
+    lodash.memoize "4.x"
+    make-error "1.x"
+    semver "7.x"
+    yargs-parser "^21.0.1"
+
 ts-node-dev@1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ts-node-dev/-/ts-node-dev-1.1.8.tgz#95520d8ab9d45fffa854d6668e2f8f9286241066"
@@ -13334,6 +13993,15 @@ v8-to-istanbul@^9.0.0:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
 
+v8-to-istanbul@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz#b6f994b0b5d4ef255e17a0d17dc444a9f5132fa4"
+  integrity sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.12"
+    "@types/istanbul-lib-coverage" "^2.0.1"
+    convert-source-map "^1.6.0"
+
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -13380,7 +14048,7 @@ walk-up-path@^1.0.0:
   resolved "https://registry.yarnpkg.com/walk-up-path/-/walk-up-path-1.0.0.tgz#d4745e893dd5fd0dbb58dd0a4c6a33d9c9fec53e"
   integrity sha512-hwj/qMDUEjCU5h0xr90KGCf0tg0/LgJbmOWgrWKYlcJZM7XvquvUJZ0G/HMGr7F7OQMOUuPHWP9JpriinkAlkg==
 
-walker@^1.0.7:
+walker@^1.0.7, walker@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f"
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
@@ -13855,6 +14523,11 @@ yargs-parser@^20.2.2, yargs-parser@^20.2.3:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
+yargs-parser@^21.0.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yargs@^16.2.0:
   version "16.2.0"


### PR DESCRIPTION
## Reference
fixes #243 

## Describe the pull request

A new event called `HARDPATCH` has been added. Also, `compressEvents` produces more compressed events and `createForest` function is used in `compressEvents`.

The `beforeUndo` field in `UndoRecord` is handy for situations when a semantic group of events have few events that are async in nature. For example, upon dropping a new component, the alias is assigned to the new component asynchronously.
