### PR TITLE
Added enum type in custom props

### DIFF
--- a/packages/custom-props-layer/src/TabBody.tsx
+++ b/packages/custom-props-layer/src/TabBody.tsx
@@ -15,6 +15,8 @@ import { InternalLink } from "./components/internal-link/InternalLink";
 import { usePageRoutes } from "./hooks/usePageRoutes";
 import { ComponentSelector } from "./components/component-selector/ComponentSelector";
 import { ExternalLink } from "./components/external-link/ExternalLink";
+import { Enum } from "./components/enum/Enum";
+import { EnumCustomProp } from "@atrilabs/app-design-forest/lib/customPropsTree";
 
 const styles: { [key: string]: React.CSSProperties } = {
   // top level container
@@ -164,6 +166,22 @@ export const TabBody: React.FC<TabBodyProps> = (props) => {
               routes={routes}
             />
           );
+        if (propType === "enum") {
+          const enumCustomProps = props.treeOptions.dataTypes[
+            propName
+          ] as EnumCustomProp;
+          const options = enumCustomProps.options;
+          return (
+            <Enum
+              {...props}
+              options={options}
+              {...options}
+              propName={propName}
+              key={propName}
+              routes={routes}
+            />
+          );
+        }
         return <React.Fragment key={propName}></React.Fragment>;
       })}
     </div>

--- a/packages/custom-props-layer/src/TabBody.tsx
+++ b/packages/custom-props-layer/src/TabBody.tsx
@@ -175,7 +175,6 @@ export const TabBody: React.FC<TabBodyProps> = (props) => {
             <Enum
               {...props}
               options={options}
-              {...options}
               propName={propName}
               key={propName}
               routes={routes}

--- a/packages/custom-props-layer/src/components/enum/Enum.tsx
+++ b/packages/custom-props-layer/src/components/enum/Enum.tsx
@@ -1,0 +1,48 @@
+import { gray900 } from "@atrilabs/design-system";
+import { useCallback, useMemo, useState } from "react";
+import { ComponentProps } from "../../types";
+import { Label } from "../commons/Label";
+import { PropertyContainer } from "../commons/PropertyContainer";
+
+export const Enum: React.FC<ComponentProps> = (props) => {
+  const propValue = useMemo(() => {
+    return props.customProps[props.propName] || "";
+  }, [props]);
+  const callPatchCb = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      props.patchCb({
+        property: {
+          custom: {
+            [props.propName]: e.target.value,
+          },
+        },
+      });
+    },
+    [props.options]
+  );
+  return (
+    <PropertyContainer>
+      <Label name={props.propName} />
+      <select
+        value={propValue}
+        onChange={callPatchCb}
+        style={{
+          height: "25px",
+          backgroundColor: gray900,
+          border: "none",
+          outline: "none",
+          color: "white",
+          padding: "0 4px",
+          minWidth: "none",
+          width: "100%",
+        }}
+      >
+        {props.options!.map((option: string, index: number) => (
+          <option value={option} key={index}>
+            {option}
+          </option>
+        ))}
+      </select>
+    </PropertyContainer>
+  );
+};

--- a/packages/custom-props-layer/src/types.ts
+++ b/packages/custom-props-layer/src/types.ts
@@ -12,6 +12,7 @@ export type TabBodyProps = {
   openColorPicker: (
     colorPickerProps: Omit<ColorPickerDialogProps, "onCrossClick">
   ) => void;
+  // options is currently being used with the enum custom property
   options?: string[];
 };
 

--- a/packages/custom-props-layer/src/types.ts
+++ b/packages/custom-props-layer/src/types.ts
@@ -12,6 +12,7 @@ export type TabBodyProps = {
   openColorPicker: (
     colorPickerProps: Omit<ColorPickerDialogProps, "onCrossClick">
   ) => void;
+  options?: string[];
 };
 
 export type ComponentProps = TabBodyProps & {

--- a/packages/react-component-manifests/src/manifests/Alert/Alert.tsx
+++ b/packages/react-component-manifests/src/manifests/Alert/Alert.tsx
@@ -116,7 +116,10 @@ const cssTreeOptions: CSSTreeOptions = {
 
 const customTreeOptions: CustomPropsTreeOptions = {
   dataTypes: {
-    alertType: { type: "text" },
+    alertType: {
+      type: "enum",
+      options: ["success", "info", "warning", "error"],
+    },
     title: { type: "text" },
     description: { type: "text" },
     successIcon: { type: "static_asset" },
@@ -153,7 +156,6 @@ const compManifest: ReactComponentManifestSchema = {
       custom: {
         treeId: CustomTreeId,
         initialValue: {
-          alertType: "success",
           title: "Alert Title",
           description: "Alert Description",
           isClosable: true,

--- a/packages/react-component-manifests/src/manifests/Alert/Alert.tsx
+++ b/packages/react-component-manifests/src/manifests/Alert/Alert.tsx
@@ -149,6 +149,7 @@ const compManifest: ReactComponentManifestSchema = {
           flexDirection: "row",
           alignItems: "flex-start",
           columnGap: "10px",
+          justifyContent: "space-between"
         },
         treeOptions: cssTreeOptions,
         canvasOptions: { groupByBreakpoint: true },


### PR DESCRIPTION
## Reference
Add reference to a related issue that this pull request is addressing. For example, fixes #462 


## Describe the pull request

Please describe the changes proposed in this pull request.

This PR intends to introduce:
- Enum type in the custom props which will be used as a property type by components customTreeOptions.
- The alert component, has a property called alertType which would render the component based on the type i.e. (success, info, warning, error). The alertType property was a text field which would mean that it could take values outside of the enum. In this PR the property field type has been changed to enum.

## Contributors (in case of a commit with multiple authors)

Co-authors:
