### PR TITLE
canas moved inside iframe

### DIFF
--- a/packages/canvas-runtime/src/Canvas.tsx
+++ b/packages/canvas-runtime/src/Canvas.tsx
@@ -1,4 +1,5 @@
 import { Container, getRef } from "@atrilabs/core";
+import { gray500 } from "@atrilabs/design-system";
 import React, { useEffect, useRef, useState } from "react";
 import ReactDOM from "react-dom";
 import { DecoratorRenderer } from "./DecoratorRenderer";
@@ -21,8 +22,7 @@ const styles: { [key: string]: React.CSSProperties } = {
   "canvas-subcontainer": {
     background: "white",
     boxSizing: "border-box",
-    overflow: "auto",
-    border: "6px solid #6b7280",
+    overflow: "hidden",
   },
 };
 
@@ -83,14 +83,14 @@ export const Canvas: React.FC = React.memo(() => {
                 <iframe
                   title="canvas"
                   ref={setIframeRef}
-                  style={{ width: "100%", height: "100%" }}
+                  style={{ width: "100%", height: "100%", border: "none" }}
                 >
                   {iframeRef && iframeRef.contentDocument
                     ? ReactDOM.createPortal(
                         <>
                           <style
                             dangerouslySetInnerHTML={{
-                              __html: `* {padding: 0; margin: 0;}`,
+                              __html: `* {padding: 0; margin: 0;} body {padding: 10px; box-shadow: inset 0 0 0 10px ${gray500};}`,
                             }}
                           ></style>
                           <DecoratorRenderer compId="body" decoratorIndex={0} />

--- a/packages/canvas-runtime/src/Canvas.tsx
+++ b/packages/canvas-runtime/src/Canvas.tsx
@@ -30,7 +30,7 @@ export const Canvas: React.FC = React.memo(() => {
   const dimension = useAutoResize(ref, breakpoint);
   const dragzoneRef = getRef("Dragzone");
   const [iframeRef, setIframeRef] = useState<HTMLIFrameElement | null>(null);
-  const overlay = useDragDrop(dragzoneRef, iframeRef);
+  const { overlay, canvasOverlay } = useDragDrop(dragzoneRef, iframeRef);
   const { stylesheets } = useSubscribeStylesheetUpdates();
   useEffect(() => {
     if (iframeRef && iframeRef.contentWindow) {
@@ -83,7 +83,14 @@ export const Canvas: React.FC = React.memo(() => {
                 >
                   {iframeRef && iframeRef.contentDocument
                     ? ReactDOM.createPortal(
-                        <DecoratorRenderer compId="body" decoratorIndex={0} />,
+                        <>
+                          <DecoratorRenderer compId="body" decoratorIndex={0} />
+                          {canvasOverlay ? (
+                            <div style={canvasOverlay.style}>
+                              <canvasOverlay.comp {...canvasOverlay.props} />
+                            </div>
+                          ) : null}
+                        </>,
                         iframeRef.contentDocument.body
                       )
                     : null}

--- a/packages/canvas-runtime/src/Canvas.tsx
+++ b/packages/canvas-runtime/src/Canvas.tsx
@@ -4,6 +4,7 @@ import ReactDOM from "react-dom";
 import { DecoratorRenderer } from "./DecoratorRenderer";
 import { acknowledgeEventPropagation } from "./decorators/CanvasActivityDecorator";
 import { useAutoResize } from "./hooks/useAutoResize";
+import { useBindEvents } from "./hooks/useBindEvents";
 import { useBreakpoint } from "./hooks/useBreakpoint";
 import { useDragDrop } from "./hooks/useDragDrop";
 import { useHintOverlays } from "./hooks/useHintOverlays";
@@ -39,6 +40,7 @@ export const Canvas: React.FC = React.memo(() => {
     }
   }, [iframeRef, iframeRef?.contentWindow]);
   const hintOverlays = useHintOverlays();
+  useBindEvents(iframeRef);
   return (
     <>
       <div

--- a/packages/canvas-runtime/src/Canvas.tsx
+++ b/packages/canvas-runtime/src/Canvas.tsx
@@ -6,6 +6,7 @@ import { acknowledgeEventPropagation } from "./decorators/CanvasActivityDecorato
 import { useAutoResize } from "./hooks/useAutoResize";
 import { useBreakpoint } from "./hooks/useBreakpoint";
 import { useDragDrop } from "./hooks/useDragDrop";
+import { useHintOverlays } from "./hooks/useHintOverlays";
 import { useSubscribeStylesheetUpdates } from "./hooks/useSubscribeStylesheet";
 import stylesModule from "./styles.module.css";
 
@@ -37,6 +38,7 @@ export const Canvas: React.FC = React.memo(() => {
       acknowledgeEventPropagation(iframeRef.contentWindow);
     }
   }, [iframeRef, iframeRef?.contentWindow]);
+  const hintOverlays = useHintOverlays();
   return (
     <>
       <div
@@ -84,12 +86,24 @@ export const Canvas: React.FC = React.memo(() => {
                   {iframeRef && iframeRef.contentDocument
                     ? ReactDOM.createPortal(
                         <>
+                          <style
+                            dangerouslySetInnerHTML={{
+                              __html: `* {padding: 0; margin: 0;}`,
+                            }}
+                          ></style>
                           <DecoratorRenderer compId="body" decoratorIndex={0} />
                           {canvasOverlay ? (
                             <div style={canvasOverlay.style}>
                               <canvasOverlay.comp {...canvasOverlay.props} />
                             </div>
                           ) : null}
+                          {/*
+                          hint overlays are sibling of body because they need to be scroll along with
+                          the component they are overlayed with respect to.
+                          */}
+                          {hintOverlays.map((hint) => {
+                            return hint;
+                          })}
                         </>,
                         iframeRef.contentDocument.body
                       )

--- a/packages/canvas-runtime/src/Canvas.tsx
+++ b/packages/canvas-runtime/src/Canvas.tsx
@@ -29,9 +29,9 @@ export const Canvas: React.FC = React.memo(() => {
   const ref = useRef<HTMLDivElement>(null);
   const dimension = useAutoResize(ref, breakpoint);
   const dragzoneRef = getRef("Dragzone");
-  const overlay = useDragDrop(dragzoneRef);
-  const { stylesheets } = useSubscribeStylesheetUpdates();
   const [iframeRef, setIframeRef] = useState<HTMLIFrameElement | null>(null);
+  const overlay = useDragDrop(dragzoneRef, iframeRef);
+  const { stylesheets } = useSubscribeStylesheetUpdates();
   useEffect(() => {
     if (iframeRef && iframeRef.contentWindow) {
       acknowledgeEventPropagation(iframeRef.contentWindow);

--- a/packages/canvas-runtime/src/body/BodyComponent.tsx
+++ b/packages/canvas-runtime/src/body/BodyComponent.tsx
@@ -8,16 +8,6 @@ const styles: { [key: string]: React.CSSProperties } = {
     boxSizing: "border-box",
     position: "relative",
     overflow: "auto",
-    /**
-     * Setting paddingTop and paddingBottom prevents the problem
-     * of parent element getting shifted if first child's top-margin
-     * is non-zero.
-     *
-     * See this:
-     * https://stackoverflow.com/questions/1762539/margin-on-child-element-moves-parent-element
-     */
-    paddingTop: "10px",
-    paddingBottom: "10px",
   },
 };
 

--- a/packages/canvas-runtime/src/decorators/CanvasActivityDecorator.tsx
+++ b/packages/canvas-runtime/src/decorators/CanvasActivityDecorator.tsx
@@ -890,15 +890,17 @@ service.start();
 let overHandled = false;
 let upHandled = false;
 let downHandled = false;
-window.addEventListener("mousemove", () => {
-  overHandled = false;
-});
-window.addEventListener("mouseup", () => {
-  upHandled = false;
-});
-window.addEventListener("mousedown", () => {
-  downHandled = false;
-});
+export function acknowledgeEventPropagation(iFrameWindow: Window) {
+  iFrameWindow.addEventListener("mousemove", () => {
+    overHandled = false;
+  });
+  iFrameWindow.addEventListener("mouseup", () => {
+    upHandled = false;
+  });
+  iFrameWindow.addEventListener("mousedown", () => {
+    downHandled = false;
+  });
+}
 
 const CanvasActivityDecorator: React.FC<DecoratorProps> = (props) => {
   useEffect(() => {

--- a/packages/canvas-runtime/src/hooks/useBindEvents.ts
+++ b/packages/canvas-runtime/src/hooks/useBindEvents.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+/**
+ * This hook binds iFrame.contentWindow events with window
+ * @param iFrame
+ */
+export const useBindEvents = (iFrame: HTMLIFrameElement | null) => {
+  useEffect(() => {
+    const bindKeydownEvent = (event: KeyboardEvent) => {
+      const keydownEvent = new KeyboardEvent("keydown", event);
+      window.dispatchEvent(keydownEvent);
+    };
+    iFrame?.contentWindow?.addEventListener("keydown", bindKeydownEvent);
+    return () => {
+      iFrame?.contentWindow?.removeEventListener("keydown", bindKeydownEvent);
+    };
+  }, [iFrame]);
+};

--- a/packages/canvas-runtime/src/hooks/useDragDrop.ts
+++ b/packages/canvas-runtime/src/hooks/useDragDrop.ts
@@ -1,20 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { createMachine, assign, Action, interpret } from "xstate";
-import { findCatcher, getCoords } from "../utils";
 import type { StartDragArgs, DragComp, DragData, Location } from "../types";
 import {
-  canvasComponentStore,
-  canvasComponentTree,
-} from "../CanvasComponentData";
-import {
-  cancelMachineLock,
-  isMachineLocked,
   lockMachineForCompDrop,
   lockMachineForDataDrop,
   lockMachineForTemplateDrop,
-  setDataDropTarget,
-  unlockMachine,
-  unsetDataDropTarget,
 } from "../decorators/CanvasActivityDecorator";
 
 type DragDropMachineContext = {
@@ -26,6 +16,8 @@ const START_DRAG_CALLED = "START_DRAG_CALLED" as "START_DRAG_CALLED";
 const MOUSE_MOVE = "MOUSE_MOVE" as "MOUSE_MOVE";
 const MOUSE_UP = "MOUSE_UP" as "MOUSE_UP";
 const RESTART = "RESTART" as "RESTART"; // event emitted to signal that we can start over
+const CANVAS_ENTERED = "CANVAS_ENTERED" as "CANVAS_ENTERED";
+const CANVAS_EXITED = "CANVAS_EXITED" as "CANVAS_EXITED";
 
 // event type
 type DragDropMachineEvent =
@@ -35,13 +27,17 @@ type DragDropMachineEvent =
     }
   | { type: "MOUSE_MOVE"; loc: Location }
   | { type: "MOUSE_UP"; loc: Location }
-  | { type: "RESTART" };
+  | { type: "RESTART" }
+  | { type: "CANVAS_ENTERED" }
+  | { type: "CANVAS_EXITED" };
 
 // states
 const idle = "idle";
 const DRAG_START = "DRAG_START";
-const DRAG = "DRAG";
-const DRAG_END = "DRAG_END";
+const OUT_OF_CANVAS = "OUT_OF_CANVAS";
+const IN_CANVAS = "IN_CANVAS";
+const DRAG_SUCCESS = "DRAG_SUCCESS";
+const DRAG_FAILED = "DRAG_FAILED";
 
 // actions
 const onStartDragCalled: Action<
@@ -77,14 +73,27 @@ const dragDropMachine = createMachine<
       },
     },
     [DRAG_START]: {
-      on: { [MOUSE_MOVE]: { target: DRAG } },
+      on: { [MOUSE_MOVE]: { target: OUT_OF_CANVAS } },
     },
-    [DRAG]: {
+    [OUT_OF_CANVAS]: {
       on: {
-        [MOUSE_UP]: { target: DRAG_END },
+        [CANVAS_ENTERED]: { target: IN_CANVAS },
+        [MOUSE_UP]: { target: DRAG_FAILED },
       },
     },
-    [DRAG_END]: {
+    [IN_CANVAS]: {
+      on: {
+        [MOUSE_MOVE]: { target: IN_CANVAS },
+        [MOUSE_UP]: { target: DRAG_SUCCESS },
+        [CANVAS_EXITED]: { target: OUT_OF_CANVAS },
+      },
+    },
+    [DRAG_SUCCESS]: {
+      on: {
+        [RESTART]: { target: idle, actions: [resetContextAction] },
+      },
+    },
+    [DRAG_FAILED]: {
       on: {
         [RESTART]: { target: idle, actions: [resetContextAction] },
       },
@@ -93,6 +102,7 @@ const dragDropMachine = createMachine<
 });
 
 const service = interpret(dragDropMachine);
+service.start();
 
 // ============ API exposed to layers ====================================
 export function startDrag(dragComp: DragComp, dragData: DragData) {
@@ -146,15 +156,10 @@ export function isNewDropInProgress() {
 }
 
 // =============== hook used in Canvas component to enable drag & drop mechanism ==
-export const useDragDrop = (containerRef: React.RefObject<HTMLElement>) => {
-  // start and end the service alongwith canvas runtime
-  useEffect(() => {
-    service.start();
-    return () => {
-      service.stop();
-    };
-  }, []);
-
+export const useDragDrop = (
+  containerRef: React.RefObject<HTMLElement>,
+  iframeEl: HTMLIFrameElement | null
+) => {
   useEffect(() => {
     const mouseMoveCb = (event: MouseEvent) => {
       service.send({ type: "MOUSE_MOVE", loc: event });
@@ -162,19 +167,68 @@ export const useDragDrop = (containerRef: React.RefObject<HTMLElement>) => {
     const mouseUpCb = (event: MouseEvent) => {
       service.send({ type: "MOUSE_UP", loc: event });
     };
+    const mouseEnteredCb = (event: MouseEvent) => {
+      console.log("mouse entered");
+      service.send({ type: "CANVAS_ENTERED" });
+    };
+    const mouseExitedCb = (event: MouseEvent) => {
+      service.send({ type: "CANVAS_EXITED" });
+    };
+    const mouseMoveCanvas = (event: MouseEvent) => {
+      service.send({ type: "MOUSE_MOVE", loc: event });
+    };
+    const mouseUpCanvas = (event: MouseEvent) => {
+      service.send({ type: "MOUSE_UP", loc: event });
+    };
     service.onTransition((state) => {
       if (state.changed) {
         if (state.value === DRAG_START) {
           window.addEventListener("mousemove", mouseMoveCb);
           window.addEventListener("mouseup", mouseUpCb);
+          if (iframeEl !== null) {
+            iframeEl.contentWindow?.document.body.addEventListener(
+              "mouseenter",
+              mouseEnteredCb
+            );
+            iframeEl.contentWindow?.document.body.addEventListener(
+              "mouseleave",
+              mouseExitedCb
+            );
+            iframeEl.contentWindow?.document.body.addEventListener(
+              "mousemove",
+              mouseMoveCanvas
+            );
+            iframeEl.contentWindow?.document.body.addEventListener(
+              "mouseup",
+              mouseUpCanvas
+            );
+          }
         }
         if (state.value === idle) {
           window.removeEventListener("mousemove", mouseMoveCb);
           window.removeEventListener("mouseup", mouseUpCb);
+          if (iframeEl !== null) {
+            iframeEl.contentWindow?.document.body.removeEventListener(
+              "mouseenter",
+              mouseEnteredCb
+            );
+            iframeEl.contentWindow?.document.body.removeEventListener(
+              "mouseleave",
+              mouseExitedCb
+            );
+            iframeEl.contentWindow?.document.body.removeEventListener(
+              "mousemove",
+              mouseMoveCanvas
+            );
+            iframeEl.contentWindow?.document.body.removeEventListener(
+              "mouseup",
+              mouseUpCanvas
+            );
+          }
         }
       }
     });
-  }, []);
+  }, [iframeEl]);
 
   const [overlay, setOverlay] = useState<{
     comp: React.FC;
@@ -182,129 +236,12 @@ export const useDragDrop = (containerRef: React.RefObject<HTMLElement>) => {
     style: React.CSSProperties;
   } | null>(null);
   useEffect(() => {
-    const displayDragComponent = (args: StartDragArgs, loc: Location) => {
-      if (containerRef.current) {
-        // get coords of container
-        // get pageX, pageY from location
-        const containerCoords = getCoords(containerRef.current);
-        const absoluteTop = loc.pageY - containerCoords.top + 10;
-        const absoluteLeft = loc.pageX - containerCoords.left + 10;
-        const style: React.CSSProperties = {
-          top: absoluteTop,
-          left: absoluteLeft,
-          position: "absolute",
-        };
-        setOverlay({ ...args.dragComp, style });
-      }
-    };
-
-    const removeDragComponent = () => {
-      // remove child from containerRef
-      setOverlay(null);
-    };
-
-    const callNewDropSubscribers = (
-      args: StartDragArgs,
-      loc: Location,
-      caughtBy: string
-    ) => {
-      dropSubscribers.forEach((cb) => cb(args, loc, caughtBy));
-    };
-
-    const callNewDragSubscribers = (
-      args: StartDragArgs,
-      loc: Location,
-      caughtBy: string | null
-    ) => {
-      dragSubscribers.forEach((cb) => cb(args, loc, caughtBy));
-    };
-
     service.onTransition((state, event) => {
-      if (
-        state.value === DRAG &&
-        event.type === MOUSE_MOVE &&
-        state.context.startDragArgs
-      ) {
-        displayDragComponent(state.context.startDragArgs, event.loc);
-        if (state.context.startDragArgs) {
-          const caughtBy = findCatcher(
-            canvasComponentTree,
-            canvasComponentStore,
-            state.context.startDragArgs.dragData,
-            event.loc
-          );
-          // drag subscribers are informed in both the cases when caughtBy is null or non-null
-          if (caughtBy) {
-            callNewDragSubscribers(
-              state.context.startDragArgs,
-              event.loc,
-              caughtBy!.id
-            );
-          } else {
-            callNewDragSubscribers(
-              state.context.startDragArgs,
-              event.loc,
-              null
-            );
-          }
-          if (state.context.startDragArgs.dragData.type === "src") {
-            // if caughtBy is null then unset data drop target, otherwise set it
-            if (caughtBy) {
-              setDataDropTarget(caughtBy.id);
-            } else {
-              unsetDataDropTarget();
-            }
-          }
-        }
-      }
-
-      if (state.value === DRAG_END && event.type === MOUSE_UP) {
-        // remove the icon created during dragging
-        removeDragComponent();
-        if (state.context.startDragArgs) {
-          const caughtBy = findCatcher(
-            canvasComponentTree,
-            canvasComponentStore,
-            state.context.startDragArgs.dragData,
-            event.loc
-          );
-          if (caughtBy) {
-            // inform drop subscribers
-            callNewDropSubscribers(
-              state.context.startDragArgs,
-              event.loc,
-              caughtBy!.id
-            );
-          }
-          if (state.context.startDragArgs.dragData.type === "src") {
-            // if caughtBy is null then unset data drop target, otherwise set the target
-            if (caughtBy) {
-              setDataDropTarget(caughtBy.id);
-            } else {
-              unsetDataDropTarget();
-            }
-            // If we are dropping src, then we can immidiately unlock the machine,
-            // once we have set/unset the target.
-            unlockMachine();
-          }
-          // Wait for 500 ms before unlocking the machine
-          // If caughtBy is null, then immidiately unlock the machine
-          if (caughtBy) {
-            setTimeout(() => {
-              if (isMachineLocked()) {
-                cancelMachineLock();
-                console.error(
-                  "Cancel machine lock was created as a escape hatch and isn't expected to happen. Please report to Atri Labs about this error message."
-                );
-              }
-            }, 500);
-          } else {
-            cancelMachineLock();
-          }
-        }
+      if (state.value === DRAG_SUCCESS || state.value === DRAG_FAILED) {
         service.send({ type: RESTART });
       }
     });
   }, [containerRef, setOverlay]);
+
   return overlay;
 };

--- a/packages/canvas-runtime/src/hooks/useHintOverlays.tsx
+++ b/packages/canvas-runtime/src/hooks/useHintOverlays.tsx
@@ -88,6 +88,8 @@ function calculateBoxDimensions(
   return null;
 }
 
+const bodyPadding = 10;
+
 const HintOverlayBox: React.FC<HintOverlay & { scale: number }> = (props) => {
   const boxDimensions = useMemo(() => {
     return calculateBoxDimensions(props);
@@ -106,10 +108,16 @@ const HintOverlayBox: React.FC<HintOverlay & { scale: number }> = (props) => {
           style={{
             position: "absolute",
             top:
-              (compPosition.top - bodyPosition.top + box.position.top) /
+              (compPosition.top -
+                bodyPosition.top +
+                box.position.top +
+                bodyPadding) /
               props.scale,
             left:
-              (compPosition.left - bodyPosition.left + box.position.left) /
+              (compPosition.left -
+                bodyPosition.left +
+                box.position.left +
+                bodyPadding) /
               props.scale,
             width: box.dimension.width / props.scale,
             height: box.dimension.height / props.scale,

--- a/packages/canvas-runtime/src/hooks/useHintOverlays.tsx
+++ b/packages/canvas-runtime/src/hooks/useHintOverlays.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { canvasComponentStore } from "../CanvasComponentData";
-import { BoxDimension, Dimension, Position } from "../types";
+import { BoxDimension, Position } from "../types";
 import { ComponentCoords, getCoords } from "../utils";
 
 type HintDimension = {
@@ -124,25 +124,25 @@ const HintOverlayBox: React.FC<HintOverlay & { scale: number }> = (props) => {
   );
 };
 
-export const useHintOverlays = (dimension: Dimension | undefined) => {
+export const useHintOverlays = () => {
   const [hintNodes, setHintNodes] = useState<React.ReactNode[]>([]);
 
   const setNodesCb = useCallback(() => {
-    if (dimension) {
-      const hintNodeIds = Object.keys(hintOverlays);
-      const hintNodes = hintNodeIds.map((hintNodeId) => {
-        const hintOverlay = hintOverlays[hintNodeId]!;
-        return (
-          <HintOverlayBox
-            {...hintOverlay}
-            scale={dimension.scale}
-            key={hintOverlay.overlayId}
-          />
-        );
-      });
-      setHintNodes(hintNodes);
-    }
-  }, [dimension]);
+    const hintNodeIds = Object.keys(hintOverlays);
+    const hintNodes = hintNodeIds.map((hintNodeId) => {
+      const hintOverlay = hintOverlays[hintNodeId]!;
+      return (
+        <HintOverlayBox
+          {...hintOverlay}
+          // Since overlays are already inside the iframe, we don't need to scale
+          // overlays again.
+          scale={1}
+          key={hintOverlay.overlayId}
+        />
+      );
+    });
+    setHintNodes(hintNodes);
+  }, []);
 
   useEffect(() => {
     // set nodes whenever a overlay data structure is changed


### PR DESCRIPTION
## Reference
closes #491 


## Describe the pull request

- By using `ReactDOM.createPortal` to render elements in the `iframe` we avoid using the message passing between parent window and the iframe. In other words, there is a shared state in React for both the parent window and `iframe`.
- Currently, we only bind `keydown` events from `iframe.contentWindow` to the parent window. In future we might have to bind more events.
