### PR TITLE
Removed font family from barChart

### DIFF
--- a/packages/react-component-manifests/src/manifests/charts/BarChart/BarChart.tsx
+++ b/packages/react-component-manifests/src/manifests/charts/BarChart/BarChart.tsx
@@ -102,16 +102,10 @@ export const BarChart = forwardRef<
             strokeDasharray={props.custom.cartesianGrid?.strokeDasharray}
           />
         ) : null}
-        {props.custom.xAxis?.show ? (
-          <XAxis fontFamily={props.styles.fontFamily} dataKey={xAxisKey} />
-        ) : null}
-        {props.custom.yAxis?.show ? (
-          <YAxis fontFamily={props.styles.fontFamily} width={40} />
-        ) : null}
+        {props.custom.xAxis?.show ? <XAxis dataKey={xAxisKey} /> : null}
+        {props.custom.yAxis?.show ? <YAxis width={40} /> : null}
         {props.custom.toolTip?.show ? <Tooltip /> : null}
-        {props.custom.legend?.show ? (
-          <Legend fontFamily={props.styles.fontFamily} />
-        ) : null}
+        {props.custom.legend?.show ? <Legend /> : null}
         {sortedKeys.map((key, index) => {
           const fillColor =
             props.custom.options?.[key]?.fill || getColorAt(index);
@@ -231,9 +225,7 @@ const compManifest: ReactComponentManifestSchema = {
     attachProps: {
       styles: {
         treeId: CSSTreeId,
-        initialValue: {
-          fontFamily: "IBM Plex Sans",
-        },
+        initialValue: {},
         treeOptions: cssTreeOptions,
         canvasOptions: { groupByBreakpoint: true },
       },


### PR DESCRIPTION
## Reference
Add reference to a related issue that this pull request is addressing. For example, fixes #557 


## Describe the pull request

Please describe the changes proposed in this pull request.
This PR intends to remove fontFamily from BarChart as it is already inheriting the font family


## Contributors (in case of a commit with multiple authors)

Co-authors:
