### PR TITLE
fixes #580 move trees to a top hook

### DIFF
--- a/packages/component-style-layer/src/TabBody.tsx
+++ b/packages/component-style-layer/src/TabBody.tsx
@@ -22,6 +22,7 @@ import { Css2Display } from "./components/css2display/Css2Display";
 import "./TabBody.css";
 import { getAliasList } from "./utils";
 import { CssSummary } from "./components/cssSummary/CssSummary";
+import { Tree } from "@atrilabs/forest";
 
 export type TabBodyProps = {
   alias: string;
@@ -38,6 +39,8 @@ export type TabBodyProps = {
   setColorValue: (color: string, index: number) => void;
   colorValueArraySetter: (colorValues: [string]) => void;
   initialAlias: string;
+  cssTree: Tree;
+  compTree: Tree;
 };
 
 const styles: { [key: string]: React.CSSProperties } = {
@@ -110,7 +113,11 @@ export const TabBody: React.FC<TabBodyProps> = (props) => {
       <div style={{ ...smallText, color: gray300, padding: "0.5rem" }}>
         {showDuplicateAliasMessage ? "Error: This alias/name is taken." : ""}
       </div>
-      <CssSummary compId={props.compId} />
+      <CssSummary
+        compId={props.compId}
+        cssTree={props.cssTree}
+        compTree={props.compTree}
+      />
       {props.treeOptions && props.treeOptions.css2DisplayOptions ? (
         <Css2Display
           styles={props.styles}

--- a/packages/component-style-layer/src/components/commons/ColorComponent.tsx
+++ b/packages/component-style-layer/src/components/commons/ColorComponent.tsx
@@ -111,7 +111,6 @@ export const rgb2hex = ({ r, g, b, a }: Color["rgb"]) => {
 
 export const getOpacityValue = (hex: Color["hex"]) => {
   let convertedRgbValue = hex2rgb(hex);
-  console.log(convertedRgbValue);
   if (convertedRgbValue.a === undefined) {
     return "0";
   } else if (convertedRgbValue.a) {

--- a/packages/component-style-layer/src/components/cssSummary/CssSummary.tsx
+++ b/packages/component-style-layer/src/components/cssSummary/CssSummary.tsx
@@ -1,7 +1,3 @@
-import { useTree } from "@atrilabs/core";
-import CssTreeId from "@atrilabs/app-design-forest/lib/cssTree?id";
-import ComponentTreeId from "@atrilabs/app-design-forest/lib/componentTree?id";
-// import { jssToCss } from "../../../../app-generator/src/react-app-template-manager/jssToCss";
 import { getAncestors, getStylesAlias } from "@atrilabs/canvas-runtime-utils";
 import {
   gray200,
@@ -13,6 +9,21 @@ import {
 } from "@atrilabs/design-system";
 import React, { useState } from "react";
 import { ReactComponent as DropDownArrow } from "../../assets/layout-parent/dropdown-icon.svg";
+import { Tree } from "@atrilabs/forest";
+
+interface CssSummaryProp {
+  compId: string;
+  cssTree: Tree;
+  compTree: Tree;
+}
+
+interface CssOfElementProp {
+  compId: string;
+  showAlias: boolean;
+  cssTree: Tree;
+  compTree: Tree;
+}
+
 // CSS
 const styles: { [key: string]: React.CSSProperties } = {
   container: {
@@ -54,11 +65,15 @@ const styles: { [key: string]: React.CSSProperties } = {
     marginRight: ".25rem",
   },
 };
-const CssOfElement: React.FC<CssOfElementProp> = ({ compId, showAlias }) => {
-  const cssTree = useTree(CssTreeId);
-  const tree = useTree(ComponentTreeId);
-  const { alias, cssStyles } = getStylesAlias(compId, tree, cssTree);
-  const css = Object.keys(cssStyles).map((ele, index) => {
+
+const CssOfElement: React.FC<CssOfElementProp> = ({
+  compId,
+  showAlias,
+  compTree,
+  cssTree,
+}) => {
+  const { alias, cssStyles } = getStylesAlias(compId, compTree, cssTree);
+  const CSS = Object.keys(cssStyles).map((ele, index) => {
     return (
       <div key={index + ele} style={styles.cssContainer}>
         <span style={styles.cssProperty}>{ele}: </span>
@@ -71,11 +86,15 @@ const CssOfElement: React.FC<CssOfElementProp> = ({ compId, showAlias }) => {
       {showAlias && (
         <h3 style={styles.cssParentAlias}>Inherited from {alias}</h3>
       )}
-      {css}
+      {CSS}
     </div>
   );
 };
-export const CssSummary: React.FC<CssSummaryProp> = ({ compId }) => {
+export const CssSummary: React.FC<CssSummaryProp> = ({
+  compId,
+  cssTree,
+  compTree,
+}) => {
   const [showProperties, setShowProperties] = useState<boolean>(false);
   const ancestorsId = getAncestors(compId);
   const CssSummary = ancestorsId.map((ele, index) => {
@@ -85,6 +104,8 @@ export const CssSummary: React.FC<CssSummaryProp> = ({ compId }) => {
         compId={ele}
         // show alias of only of the parents
         showAlias={index >= 1 ? true : false}
+        cssTree={cssTree}
+        compTree={compTree}
       />
     );
   });
@@ -113,11 +134,3 @@ export const CssSummary: React.FC<CssSummaryProp> = ({ compId }) => {
     </div>
   );
 };
-
-interface CssSummaryProp {
-  compId: string;
-}
-interface CssOfElementProp {
-  compId: string;
-  showAlias: boolean;
-}

--- a/packages/component-style-layer/src/hooks/useGetTrees.ts
+++ b/packages/component-style-layer/src/hooks/useGetTrees.ts
@@ -1,0 +1,9 @@
+import { useTree } from "@atrilabs/core";
+import ComponentTreeId from "@atrilabs/app-design-forest/lib/componentTree?id";
+import CssTreeId from "@atrilabs/app-design-forest/lib/cssTree?id";
+
+export const useGetTrees = () => {
+  const compTree = useTree(ComponentTreeId);
+  const cssTree = useTree(CssTreeId);
+  return { compTree, cssTree };
+};

--- a/packages/component-style-layer/src/hooks/useManageCSS.ts
+++ b/packages/component-style-layer/src/hooks/useManageCSS.ts
@@ -2,13 +2,11 @@ import {
   api,
   BrowserForestManager,
   manifestRegistryController,
-  useTree,
 } from "@atrilabs/core";
 import React, { useCallback, useEffect, useState } from "react";
-import ComponentTreeId from "@atrilabs/app-design-forest/lib/componentTree?id";
 import cssTreeId from "@atrilabs/app-design-forest/lib/cssTree?id";
 import ReactManifestSchemaId from "@atrilabs/react-component-manifest-schema?id";
-import { PatchEvent } from "@atrilabs/forest";
+import { PatchEvent, Tree } from "@atrilabs/forest";
 import { ReactComponentManifestSchema } from "@atrilabs/react-component-manifest-schema/lib/types";
 import {
   getComponentProps,
@@ -18,9 +16,14 @@ import {
 } from "@atrilabs/canvas-runtime";
 import { getEffectiveStyle } from "@atrilabs/canvas-runtime-utils";
 
-export const useManageCSS = (id: string | null) => {
-  const compTree = useTree(ComponentTreeId);
-  const cssTree = useTree(cssTreeId);
+export const useManageCSS = (props: {
+  id: string | null;
+  compTree: Tree;
+  cssTree: Tree;
+}) => {
+  const id = props.id;
+  const compTree = props.compTree;
+  const cssTree = props.cssTree;
   const [styles, setStyles] = useState<React.CSSProperties>({});
   const [treeOptions, setTreeOptions] = useState<
     | ReactComponentManifestSchema["dev"]["attachProps"]["0"]["treeOptions"]
@@ -142,6 +145,8 @@ export const useManageCSS = (id: string | null) => {
                 updateComponentProps(id, { ...oldProps, ...props });
               }
             }
+
+            // TODO: update inherited styles (maybe inside a startTransition)
           }
         }
       });

--- a/packages/component-style-layer/src/hooks/useShowTab.ts
+++ b/packages/component-style-layer/src/hooks/useShowTab.ts
@@ -1,13 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { api, BrowserForestManager, useTree } from "@atrilabs/core";
+import { api, BrowserForestManager } from "@atrilabs/core";
 import { subscribeCanvasActivity } from "@atrilabs/canvas-runtime";
 import ComponentTreeId from "@atrilabs/app-design-forest/lib/componentTree?id";
 import ReactManifestSchemaId from "@atrilabs/react-component-manifest-schema?id";
-import { PatchEvent } from "@atrilabs/forest";
+import { PatchEvent, Tree } from "@atrilabs/forest";
 
-export const useShowTab = () => {
+export const useShowTab = (compTree: Tree) => {
   const [showTab, setShowTab] = useState<boolean>(false);
-  const tree = useTree(ComponentTreeId);
   const [alias, setAlias] = useState<string>("");
   const initialAlias = useRef<string>("");
   const [id, setId] = useState<string | null>(null);
@@ -41,25 +40,25 @@ export const useShowTab = () => {
       if (update.type === "change") {
         const id = update.id;
         if (
-          tree.nodes[id] &&
-          tree.nodes[id].meta.manifestSchemaId === ReactManifestSchemaId
+          compTree.nodes[id] &&
+          compTree.nodes[id].meta.manifestSchemaId === ReactManifestSchemaId
         ) {
-          const alias = tree.nodes[id].state.alias;
+          const alias = compTree.nodes[id].state.alias;
           setAlias(alias);
         }
       }
     });
     return unsub;
-  }, [tree]);
+  }, [compTree]);
 
   useEffect(() => {
     const unsub = subscribeCanvasActivity("select", (context) => {
       const id = context.select!.id;
       if (
-        tree.nodes[id] &&
-        tree.nodes[id].meta.manifestSchemaId === ReactManifestSchemaId
+        compTree.nodes[id] &&
+        compTree.nodes[id].meta.manifestSchemaId === ReactManifestSchemaId
       ) {
-        const alias = tree.nodes[id].state.alias;
+        const alias = compTree.nodes[id].state.alias;
         // When a new component is dropped, it is automatically selected, hence, it might
         // be that no alias has been created till now.
         if (alias === undefined) {
@@ -73,7 +72,7 @@ export const useShowTab = () => {
       }
     });
     return unsub;
-  }, [tree]);
+  }, [compTree]);
   useEffect(() => {
     const unsub = subscribeCanvasActivity("selectEnd", (context) => {
       setShowTab(false);
@@ -81,5 +80,11 @@ export const useShowTab = () => {
     });
     return unsub;
   }, []);
-  return { showTab, alias, setAliasCb, id, initialAlias: initialAlias.current };
+  return {
+    showTab,
+    alias,
+    setAliasCb,
+    id,
+    initialAlias: initialAlias.current,
+  };
 };

--- a/packages/component-style-layer/src/index.tsx
+++ b/packages/component-style-layer/src/index.tsx
@@ -10,14 +10,20 @@ import { useShowColorPaletteWithoutEffect } from "./hooks/useShowColorPaletteWit
 import { ColorPickerAsset } from "./components/commons/ColorPickerAsset";
 import { ColorPickerAssetWithoutEffect } from "./components/commons/ColorPickerAssetWithoutEffect";
 import { gray700 } from "@atrilabs/design-system";
+import { useGetTrees } from "./hooks/useGetTrees";
 
 /*
 This serves as the Data Manager component for this layer.
 */
 export default function () {
   // show tab and set alias
-  const { showTab, alias, setAliasCb, id, initialAlias } = useShowTab();
-  const { patchCb, styles, treeOptions, breakpoint } = useManageCSS(id);
+  const { compTree, cssTree } = useGetTrees();
+  const { showTab, alias, setAliasCb, id, initialAlias } = useShowTab(compTree);
+  const { patchCb, styles, treeOptions, breakpoint } = useManageCSS({
+    id,
+    compTree,
+    cssTree,
+  });
   const {
     openAssetManager,
     modes,
@@ -65,6 +71,8 @@ export default function () {
                 setColorValue={colorValSetter}
                 colorValueArraySetter={colorValueArraySetter}
                 initialAlias={initialAlias}
+                cssTree={cssTree}
+                compTree={compTree}
               />
               {showColorPalette && linkColorPaletteToStyleItem ? (
                 <div


### PR DESCRIPTION
## Reference
fixes #580 


## Describe the pull request

The `useTree` custom hook from `@atrilabs/core` should only be used in a single hook in each layer. Other hooks must use the tree instances from this custom hook. This is important because when the current forest is reset, there is no guarantee which `useTree` hook will fire first.