### PR TITLE
UNSET event in forest

### DIFF
--- a/packages/forest/__tests__/forest.spec.ts
+++ b/packages/forest/__tests__/forest.spec.ts
@@ -260,3 +260,38 @@ test("hard patch with selector replaces selected state", () => {
     compTree!.nodes["comp1"]!.state["breakpoints"]["991"]["styles"]["height"]
   ).toBe("20px");
 });
+
+test("unset event", () => {
+  const forest = createForest(forestDef);
+  const compTree = forest.tree(componentTreeDef.modulePath);
+  forest.handleEvents({
+    name: "TEST_EVENTS",
+    events: [
+      {
+        type: `CREATE$$${componentTreeDef.modulePath}`,
+        id: "comp1",
+        meta: {},
+        state: {
+          parent: { id: "body", index: 0 },
+        },
+      },
+      {
+        type: `PATCH$$${componentTreeDef.modulePath}`,
+        id: "comp1",
+        slice: {
+          alias: "comp1Alias",
+        },
+      },
+      {
+        type: `UNSET$$${componentTreeDef.modulePath}`,
+        id: "comp1",
+        selector: ["parent", "id"],
+      },
+    ],
+    meta: { agent: "server-sent" },
+  });
+  expect(compTree?.nodes).toBeDefined();
+  expect(compTree!.nodes["comp1"]!.state).toHaveProperty("parent");
+  expect(compTree!.nodes["comp1"]!.state.parent).toHaveProperty("index");
+  expect(compTree!.nodes["comp1"]!.state.parent).not.toHaveProperty("id");
+});

--- a/packages/forest/src/types.ts
+++ b/packages/forest/src/types.ts
@@ -77,13 +77,19 @@ export type HardPatchEvent = {
   selector?: string[];
 } & EventDto;
 
+export type UnsetEvent = {
+  id: string;
+  selector: string[];
+} & EventDto;
+
 export type AnyEvent =
   | CreateEvent
   | PatchEvent
   | DeleteEvent
   | LinkEvent
   | UnlinkEvent
-  | HardPatchEvent;
+  | HardPatchEvent
+  | UnsetEvent;
 
 export type TreeDefReturnType = {
   validateCreate: (event: CreateEvent) => boolean;


### PR DESCRIPTION
Added `UNSET` event to delete a field in the state of a node.
