### PR TITLE
Fixed re-drop inside a canvas zone

### DIFF
--- a/packages/atri-app-core/src/api/canvasApi.ts
+++ b/packages/atri-app-core/src/api/canvasApi.ts
@@ -100,7 +100,6 @@ subscribeCanvasMachine("upWhileDrag", (context) => {
 });
 
 subscribeCanvasMachine("repositionSuccess", (context) => {
-  console.log("Reposition atri-app-core: ", context.repositionTarget);
   const canvasZone = (context.repositionTarget!.target as HTMLElement).closest(
     "[data-atri-canvas-id]"
   );
@@ -287,13 +286,8 @@ if (typeof window !== "undefined") {
     }
     if (ev.data?.type === "REWIRE_COMPONENT") {
       const payload = ev.data.payload as RewireUpdate;
-      const newParent = {
-        ...payload.newParent,
-        canvasZoneId:
-          (payload.newParent as any).zoneId ||
-          (payload.newParent as any).canvasZoneId,
-      };
-      componentStoreApi.rewireComponent(payload.compId, { ...newParent });
+      const newParent = payload.newParent as any;
+      componentStoreApi.rewireComponent(payload.compId, newParent);
     }
   });
   window.document.addEventListener(

--- a/packages/atri-app-core/src/canvasMachine.ts
+++ b/packages/atri-app-core/src/canvasMachine.ts
@@ -549,7 +549,6 @@ export function createCanvasMachine(id: string) {
               on: {
                 [MOUSE_DOWN]: {
                   target: pressed,
-                  cond: selectedDifferentComponent,
                   actions: ["setMousePosition"],
                 },
               },

--- a/packages/atri-app-core/src/editor-components/CanvasZoneRenderer/hooks/useCanvasZoneEventSubscriber.ts
+++ b/packages/atri-app-core/src/editor-components/CanvasZoneRenderer/hooks/useCanvasZoneEventSubscriber.ts
@@ -9,9 +9,9 @@ export function useCanvasZoneEventSubscriber(params: { canvasZoneId: string }) {
       "new_component",
       () => {
         if (componentStoreApi.getCanvasZoneChildrenId(params.canvasZoneId))
-          setChildCompIds(
-            componentStoreApi.getCanvasZoneChildrenId(params.canvasZoneId)
-          );
+          setChildCompIds([
+            ...componentStoreApi.getCanvasZoneChildrenId(params.canvasZoneId),
+          ]);
       }
     );
   }, []);
@@ -21,9 +21,9 @@ export function useCanvasZoneEventSubscriber(params: { canvasZoneId: string }) {
       "children_updated",
       () => {
         if (componentStoreApi.getCanvasZoneChildrenId(params.canvasZoneId))
-          setChildCompIds(
-            componentStoreApi.getCanvasZoneChildrenId(params.canvasZoneId)
-          );
+          setChildCompIds([
+            ...componentStoreApi.getCanvasZoneChildrenId(params.canvasZoneId),
+          ]);
       }
     );
   }, []);

--- a/packages/atri-app-core/src/editor-components/ParentComponentRenderer/hooks/useHandleNewChild.ts
+++ b/packages/atri-app-core/src/editor-components/ParentComponentRenderer/hooks/useHandleNewChild.ts
@@ -8,7 +8,7 @@ export function useHandleNewChild(props: { id: string }) {
 
   useEffect(() => {
     return canvasApi.subscribeComponentEvent(props.id, "new_component", () => {
-      setChildren(componentStoreApi.getComponentChildrenId(props.id));
+      setChildren([...componentStoreApi.getComponentChildrenId(props.id)]);
     });
   }, [props.id]);
 
@@ -17,7 +17,7 @@ export function useHandleNewChild(props: { id: string }) {
       props.id,
       "children_updated",
       () => {
-        setChildren(componentStoreApi.getComponentChildrenId(props.id));
+        setChildren([...componentStoreApi.getComponentChildrenId(props.id)]);
       }
     );
   });

--- a/packages/core/src/utils/createComponentFromNode.ts
+++ b/packages/core/src/utils/createComponentFromNode.ts
@@ -56,7 +56,7 @@ export function createComponentFromNode(
   const parent = {
     id: node.state.parent.id,
     index: node.state.parent.index,
-    canvasZoneId: node.state.parent.zoneId,
+    canvasZoneId: node.state.parent.canvasZoneId,
   };
   // find manifest from manifest registry
   const manifestRegistry = manifestRegistryController.readManifestRegistry();

--- a/packages/core/src/utils/createEventsFromManifest.ts
+++ b/packages/core/src/utils/createEventsFromManifest.ts
@@ -35,7 +35,7 @@ export function createEventsFromManifest(options: {
       type: `CREATE$$${treeId}`,
       meta: {},
       state: {
-        parent: { id: "", index: 0, zoneId: "" },
+        parent: { id: "", index: 0 },
         // NOTE: Introducting a convention to store node value in state's property field
         property: { [propKey]: initialValue },
       },
@@ -58,7 +58,7 @@ export function createEventsFromManifest(options: {
     type: `CREATE$$${CallbackTreeId}`,
     meta: {},
     state: {
-      parent: { id: "", index: 0, zoneId: "" },
+      parent: { id: "", index: 0 },
       // NOTE: Introducting a convention to store node value in state's property field
       property: { callbacks: defaultCallbacks },
     },
@@ -82,11 +82,7 @@ export function createEventsFromManifest(options: {
       manifestSchemaId: manifestSchema,
     },
     state: {
-      parent: {
-        id: parent.id,
-        index: parent.index,
-        zoneId: parent.canvasZoneId,
-      },
+      parent,
     },
   };
   events.push(event);

--- a/packages/forest/__tests__/events/test_1.json
+++ b/packages/forest/__tests__/events/test_1.json
@@ -1,0 +1,167 @@
+[
+  {
+    "id": "3f638155-cf07-4470-be58-c75140979919",
+    "type": "CREATE$$@atrilabs/app-design-forest/src/cssTree",
+    "meta": {},
+    "state": {
+      "parent": {
+        "id": "",
+        "index": 0
+      },
+      "property": {
+        "styles": {
+          "color": "#fff",
+          "backgroundColor": "#1890ff",
+          "paddingTop": "8px",
+          "paddingLeft": "15px",
+          "paddingBottom": "8px",
+          "paddingRight": "15px",
+          "fontSize": "16px",
+          "borderRadius": "2px",
+          "outline": "none",
+          "fontWeight": 400,
+          "textAlign": "center",
+          "borderWidth": "1px",
+          "borderStyle": "solid",
+          "borderColor": "#1890ff",
+          "cursor": "pointer",
+          "userSelect": "none"
+        }
+      }
+    }
+  },
+  {
+    "type": "LINK$$@atrilabs/app-design-forest/src/cssTree",
+    "refId": "9d85fe5f-52ae-4b96-a133-0bd9298a8d36",
+    "childId": "3f638155-cf07-4470-be58-c75140979919"
+  },
+  {
+    "id": "b66abff5-2b25-4113-a0a7-ac9240ace966",
+    "type": "CREATE$$@atrilabs/app-design-forest/src/customPropsTree",
+    "meta": {},
+    "state": {
+      "parent": {
+        "id": "",
+        "index": 0
+      },
+      "property": {
+        "custom": {
+          "text": "Submit"
+        }
+      }
+    }
+  },
+  {
+    "type": "LINK$$@atrilabs/app-design-forest/src/customPropsTree",
+    "refId": "9d85fe5f-52ae-4b96-a133-0bd9298a8d36",
+    "childId": "b66abff5-2b25-4113-a0a7-ac9240ace966"
+  },
+  {
+    "type": "LINK$$@atrilabs/app-design-forest/src/callbackHandlerTree",
+    "refId": "9d85fe5f-52ae-4b96-a133-0bd9298a8d36",
+    "childId": "ad977d46-20af-4ad5-bf33-e3f15f8e1a7d"
+  },
+  {
+    "id": "9d85fe5f-52ae-4b96-a133-0bd9298a8d36",
+    "type": "CREATE$$@atrilabs/app-design-forest/src/componentTree",
+    "meta": {
+      "pkg": "@atrilabs/react-component-manifests",
+      "key": "Button",
+      "manifestSchemaId": "@atrilabs/react-component-manifest-schema/src/index.ts"
+    },
+    "state": {
+      "parent": {
+        "id": "__atri_canvas_zone_root__",
+        "index": 1,
+        "canvasZoneId": "canvas1"
+      }
+    }
+  },
+  {
+    "id": "ad977d46-20af-4ad5-bf33-e3f15f8e1a7d",
+    "type": "CREATE$$@atrilabs/app-design-forest/src/callbackHandlerTree",
+    "meta": {},
+    "state": {
+      "parent": {
+        "id": "",
+        "index": 0
+      },
+      "property": {
+        "callbacks": {
+          "onClick": [
+            {
+              "sendEventData": true
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": "04a7ae8c-ee02-4c0f-abc6-461b014c58e7",
+    "type": "CREATE$$@atrilabs/app-design-forest/src/cssTree",
+    "meta": {},
+    "state": {
+      "parent": {
+        "id": "",
+        "index": 0
+      },
+      "property": {
+        "styles": {
+          "display": "flex"
+        }
+      }
+    }
+  },
+  {
+    "id": "5c5d56e4-9245-47f1-a127-550da3651522",
+    "type": "CREATE$$@atrilabs/app-design-forest/src/callbackHandlerTree",
+    "meta": {},
+    "state": {
+      "parent": {
+        "id": "",
+        "index": 0
+      },
+      "property": {
+        "callbacks": {}
+      }
+    }
+  },
+  {
+    "type": "LINK$$@atrilabs/app-design-forest/src/callbackHandlerTree",
+    "refId": "8e50f6d3-332d-4faa-85fe-d6eb17424147",
+    "childId": "5c5d56e4-9245-47f1-a127-550da3651522"
+  },
+  {
+    "id": "8e50f6d3-332d-4faa-85fe-d6eb17424147",
+    "type": "CREATE$$@atrilabs/app-design-forest/src/componentTree",
+    "meta": {
+      "pkg": "@atrilabs/react-component-manifests",
+      "key": "Flex",
+      "manifestSchemaId": "@atrilabs/react-component-manifest-schema/src/index.ts"
+    },
+    "state": {
+      "parent": {
+        "id": "__atri_canvas_zone_root__",
+        "index": 1,
+        "canvasZoneId": "canvas2"
+      }
+    }
+  },
+  {
+    "type": "LINK$$@atrilabs/app-design-forest/src/cssTree",
+    "refId": "8e50f6d3-332d-4faa-85fe-d6eb17424147",
+    "childId": "04a7ae8c-ee02-4c0f-abc6-461b014c58e7"
+  },
+  {
+    "type": "PATCH$$@atrilabs/app-design-forest/src/componentTree",
+    "id": "9d85fe5f-52ae-4b96-a133-0bd9298a8d36",
+    "slice": {
+      "parent": {
+        "id": "8e50f6d3-332d-4faa-85fe-d6eb17424147",
+        "index": 1,
+        "canvasZoneId": "canvas2"
+      }
+    }
+  }
+]

--- a/packages/forest/__tests__/forest.spec.ts
+++ b/packages/forest/__tests__/forest.spec.ts
@@ -1,5 +1,7 @@
 import { createForest } from "../src/forest";
 import { componentTreeDef, cssTreeDef, forestDef } from "./forestDefExample";
+import fs from "fs";
+import path from "path";
 
 test("createForest fn returns a forest with trees", () => {
   const forest = createForest(forestDef);
@@ -294,4 +296,27 @@ test("unset event", () => {
   expect(compTree!.nodes["comp1"]!.state).toHaveProperty("parent");
   expect(compTree!.nodes["comp1"]!.state.parent).toHaveProperty("index");
   expect(compTree!.nodes["comp1"]!.state.parent).not.toHaveProperty("id");
+});
+
+test("patch event with canvas zone", () => {
+  const events = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "events", "test_1.json")).toString()
+  );
+  const forest = createForest(forestDef);
+  const compTree = forest.tree(componentTreeDef.modulePath);
+  forest.handleEvents({ name: "", events, meta: { agent: "server-sent" } });
+  expect(compTree?.nodes).toBeDefined();
+  expect(
+    compTree!.nodes["9d85fe5f-52ae-4b96-a133-0bd9298a8d36"]!.state
+  ).toHaveProperty("parent");
+  expect(
+    compTree!.nodes["9d85fe5f-52ae-4b96-a133-0bd9298a8d36"]!.state.parent
+  ).toHaveProperty("index");
+  expect(
+    compTree!.nodes["9d85fe5f-52ae-4b96-a133-0bd9298a8d36"]!.state.parent
+  ).toHaveProperty("canvasZoneId");
+  expect(
+    compTree!.nodes["9d85fe5f-52ae-4b96-a133-0bd9298a8d36"]!.state.parent.id
+  ).toBe("8e50f6d3-332d-4faa-85fe-d6eb17424147");
+  expect(events).toBeDefined();
 });

--- a/packages/forest/__tests__/forestDefExample.ts
+++ b/packages/forest/__tests__/forestDefExample.ts
@@ -1,8 +1,8 @@
 import { ForestDef, TreeDef } from "../src/types";
 
 export const componentTreeDef: TreeDef = {
-  id: "@atrilabs/app-design-forest/lib/componentTree.js",
-  modulePath: "@atrilabs/app-design-forest/lib/componentTree.js",
+  id: "@atrilabs/app-design-forest/src/componentTree",
+  modulePath: "@atrilabs/app-design-forest/src/componentTree",
   defFn: () => {
     return {
       validateCreate(_event) {
@@ -17,8 +17,8 @@ export const componentTreeDef: TreeDef = {
 };
 
 export const cssTreeDef: TreeDef = {
-  id: "@atrilabs/app-design-forest/lib/cssTree.js",
-  modulePath: "@atrilabs/app-design-forest/lib/cssTree.js",
+  id: "@atrilabs/app-design-forest/src/cssTree",
+  modulePath: "@atrilabs/app-design-forest/src/cssTree",
   defFn: () => {
     return {
       validateCreate(_event) {
@@ -33,8 +33,8 @@ export const cssTreeDef: TreeDef = {
 };
 
 export const callbackTreeDef: TreeDef = {
-  id: "@atrilabs/app-design-forest/lib/callbackHandlerTree.js",
-  modulePath: "@atrilabs/app-design-forest/lib/callbackHandlerTree.js",
+  id: "@atrilabs/app-design-forest/src/callbackHandlerTree",
+  modulePath: "@atrilabs/app-design-forest/src/callbackHandlerTree",
   defFn: () => {
     return {
       validateCreate(_event) {
@@ -49,8 +49,8 @@ export const callbackTreeDef: TreeDef = {
 };
 
 export const customPropsTreeDef: TreeDef = {
-  id: "@atrilabs/app-design-forest/lib/customPropsTree.js",
-  modulePath: "@atrilabs/app-design-forest/lib/customPropsTree.js",
+  id: "@atrilabs/app-design-forest/src/customPropsTree",
+  modulePath: "@atrilabs/app-design-forest/src/customPropsTree",
   defFn: () => {
     return {
       validateCreate(_event) {

--- a/packages/forest/jest.config.js
+++ b/packages/forest/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
-  modulePathIgnorePatterns: ["forestDefExample.ts"],
+  modulePathIgnorePatterns: ["forestDefExample.ts", "events"],
 };

--- a/packages/forest/src/types.ts
+++ b/packages/forest/src/types.ts
@@ -9,7 +9,7 @@ export type TreeNode = {
    * contains state of the element
    */
   state: { [key: string]: any } & {
-    parent: { id: string; index: number; zoneId: string };
+    parent: { id: string; index: number } & { [key: string]: any };
   };
 };
 

--- a/packages/react-component-manifests/src/manifests/Flex/Flex.dev.tsx
+++ b/packages/react-component-manifests/src/manifests/Flex/Flex.dev.tsx
@@ -7,8 +7,8 @@ const DevFlex: typeof Flex = forwardRef((props, ref) => {
     props.children.length === 0
       ? {
           // do not provide minHeight minWidth if user has provided height width
-          minHeight: props.styles.height ? "" : "100px",
-          minWidth: props.styles.width ? "" : "100px",
+          minHeight: props.styles?.height ? "" : "100px",
+          minWidth: props.styles?.width ? "" : "100px",
           borderWidth: `2px`,
           borderStyle: `dashed`,
           borderColor: `${gray500}`,


### PR DESCRIPTION
Bug -

Re-drop when the new parent is canvas zone wasn't working.

Fix -

Changed the condition that checks whether the new target for drop is valid.