### PR TITLE
State orchestration bugs resolved

### DIFF
--- a/packages/atri-app-core/src/canvasMachine.ts
+++ b/packages/atri-app-core/src/canvasMachine.ts
@@ -522,12 +522,10 @@ export function createCanvasMachine(id: string) {
             [hover]: {
               entry: (context, event) => {
                 callSubscribers("hover", context, event);
-                console.log("Entered hover state");
               },
               exit: (context, event) => {
                 context.hovered = null;
                 callSubscribers("hoverEnd", context, event);
-                console.log("Exited hover state");
               },
               on: {
                 [MOUSE_MOVE]: {
@@ -548,12 +546,6 @@ export function createCanvasMachine(id: string) {
               },
             },
             [pressed]: {
-              entry: () => {
-                console.log("Entered pressed state");
-              },
-              exit: () => {
-                console.log("Exited pressed state");
-              },
               on: {
                 [MOUSE_UP]: {
                   target: selected,
@@ -624,12 +616,10 @@ export function createCanvasMachine(id: string) {
             [selected]: {
               entry: (context, event) => {
                 callSubscribers("select", context, event);
-                console.log("Entered selected state");
               },
               exit: (context, event) => {
                 callSubscribers("selectEnd", context, event);
                 context.selected = null;
-                console.log("Exited selected state");
               },
               on: {
                 [MOUSE_DOWN]: [

--- a/packages/atri-app-core/src/canvasMachine.ts
+++ b/packages/atri-app-core/src/canvasMachine.ts
@@ -515,10 +515,12 @@ export function createCanvasMachine(id: string) {
             [hover]: {
               entry: (context, event) => {
                 callSubscribers("hover", context, event);
+                console.log("Entered hover state");
               },
               exit: (context, event) => {
                 context.hovered = null;
                 callSubscribers("hoverEnd", context, event);
+                console.log("Exited hover state");
               },
               on: {
                 [MOUSE_MOVE]: {
@@ -539,6 +541,12 @@ export function createCanvasMachine(id: string) {
               },
             },
             [pressed]: {
+              entry: () => {
+                console.log("Entered pressed state");
+              },
+              exit: () => {
+                console.log("Exited pressed state");
+              },
               on: {
                 [MOUSE_UP]: {
                   target: selected,
@@ -609,14 +617,17 @@ export function createCanvasMachine(id: string) {
             [selected]: {
               entry: (context, event) => {
                 callSubscribers("select", context, event);
+                console.log("Entered selected state");
               },
               exit: (context, event) => {
                 callSubscribers("selectEnd", context, event);
                 context.selected = null;
+                console.log("Exited selected state");
               },
               on: {
                 [MOUSE_DOWN]: {
                   target: pressed,
+                  cond: insideComponent,
                   actions: ["setMousePosition"],
                 },
               },

--- a/packages/atri-app-core/src/canvasMachine.ts
+++ b/packages/atri-app-core/src/canvasMachine.ts
@@ -275,6 +275,13 @@ function insideComponent(
   return false;
 }
 
+function notInsideComponent(
+  context: CanvasMachineContext,
+  event: MOUSE_DOWN_EVENT
+) {
+  return !insideComponent(context, event);
+}
+
 function hoveringOverDifferentComponent(
   context: CanvasMachineContext,
   event: MOUSE_MOVE_EVENT
@@ -625,11 +632,17 @@ export function createCanvasMachine(id: string) {
                 console.log("Exited selected state");
               },
               on: {
-                [MOUSE_DOWN]: {
-                  target: pressed,
-                  cond: insideComponent,
-                  actions: ["setMousePosition"],
-                },
+                [MOUSE_DOWN]: [
+                  {
+                    target: pressed,
+                    cond: insideComponent,
+                    actions: ["setMousePosition"],
+                  },
+                  {
+                    target: `#${id}.${ready}.${idle}`,
+                    cond: notInsideComponent,
+                  },
+                ],
               },
               type: "parallel",
               states: {

--- a/packages/atri-app-core/src/editor-components/CanvasOverlay/hooks/useSelectHints.tsx
+++ b/packages/atri-app-core/src/editor-components/CanvasOverlay/hooks/useSelectHints.tsx
@@ -17,21 +17,21 @@ export function useSelectHints() {
   const leftLineHoverId = useRef<string | null>(null);
   const compId = useRef<string | null>(null);
 
-  const clearOverlay = useCallback((canvasZoneIdForSelectEnd?: string) => {
+  const clearOverlay = useCallback(() => {
     if (topLineHoverId.current) {
-      removeHintOverlays([topLineHoverId.current], canvasZoneIdForSelectEnd);
+      removeHintOverlays([topLineHoverId.current]);
       topLineHoverId.current = null;
     }
     if (rightLineHoverId.current) {
-      removeHintOverlays([rightLineHoverId.current], canvasZoneIdForSelectEnd);
+      removeHintOverlays([rightLineHoverId.current]);
       rightLineHoverId.current = null;
     }
     if (bottomLineHoverId.current) {
-      removeHintOverlays([bottomLineHoverId.current], canvasZoneIdForSelectEnd);
+      removeHintOverlays([bottomLineHoverId.current]);
       bottomLineHoverId.current = null;
     }
     if (leftLineHoverId.current) {
-      removeHintOverlays([leftLineHoverId.current], canvasZoneIdForSelectEnd);
+      removeHintOverlays([leftLineHoverId.current]);
       leftLineHoverId.current = null;
     }
   }, []);
@@ -128,11 +128,7 @@ export function useSelectHints() {
 
   useEffect(() => {
     return subscribeCanvasMachine("selectEnd", (context, event: any) => {
-      if (event.type === "COMPONENT_DELETED") {
-        clearOverlay(event.comp!.parent.canvasZoneId);
-      } else {
-        clearOverlay();
-      }
+      clearOverlay();
       compId.current = null;
     });
   }, []);

--- a/packages/atri-app-core/src/editor-components/CanvasOverlay/hooks/useSelectHints.tsx
+++ b/packages/atri-app-core/src/editor-components/CanvasOverlay/hooks/useSelectHints.tsx
@@ -17,21 +17,21 @@ export function useSelectHints() {
   const leftLineHoverId = useRef<string | null>(null);
   const compId = useRef<string | null>(null);
 
-  const clearOverlay = useCallback(() => {
+  const clearOverlay = useCallback((canvasZoneIdForSelectEnd?: string) => {
     if (topLineHoverId.current) {
-      removeHintOverlays([topLineHoverId.current]);
+      removeHintOverlays([topLineHoverId.current], canvasZoneIdForSelectEnd);
       topLineHoverId.current = null;
     }
     if (rightLineHoverId.current) {
-      removeHintOverlays([rightLineHoverId.current]);
+      removeHintOverlays([rightLineHoverId.current], canvasZoneIdForSelectEnd);
       rightLineHoverId.current = null;
     }
     if (bottomLineHoverId.current) {
-      removeHintOverlays([bottomLineHoverId.current]);
+      removeHintOverlays([bottomLineHoverId.current], canvasZoneIdForSelectEnd);
       bottomLineHoverId.current = null;
     }
     if (leftLineHoverId.current) {
-      removeHintOverlays([leftLineHoverId.current]);
+      removeHintOverlays([leftLineHoverId.current], canvasZoneIdForSelectEnd);
       leftLineHoverId.current = null;
     }
   }, []);
@@ -127,8 +127,12 @@ export function useSelectHints() {
   }, []);
 
   useEffect(() => {
-    return subscribeCanvasMachine("selectEnd", (context, event) => {
-      clearOverlay();
+    return subscribeCanvasMachine("selectEnd", (context, event: any) => {
+      if (event.type === "COMPONENT_DELETED") {
+        clearOverlay(event.comp!.parent.canvasZoneId);
+      } else {
+        clearOverlay();
+      }
       compId.current = null;
     });
   }, []);

--- a/packages/atri-app-core/src/editor-components/VisualHints/hintOverlays.ts
+++ b/packages/atri-app-core/src/editor-components/VisualHints/hintOverlays.ts
@@ -27,20 +27,18 @@ export function addOrModifyHintOverlays(overlays: {
   });
 }
 
-export function removeHintOverlays(
-  overlayIds: string[],
-  canvasZoneIdForSelectEnd?: string
-) {
+export function removeHintOverlays(overlayIds: string[]) {
   const affectedCanvasZones: Set<string> = new Set();
   overlayIds.forEach((overlayId) => {
     if (!hintOverlays[overlayId]) {
       return;
     }
     const overlay = hintOverlays[overlayId]!;
-    const canvasZoneId =
-      canvasZoneIdForSelectEnd !== undefined
-        ? canvasZoneIdForSelectEnd
-        : componentStoreApi.getComponent(overlay.compId)!.parent.canvasZoneId;
+    let canvasZoneId = "";
+    for (const property in overlayCanvasZoneMap) {
+      if (overlayCanvasZoneMap[property].includes(overlay.overlayId))
+        canvasZoneId = property;
+    }
     affectedCanvasZones.add(canvasZoneId);
     if (hintOverlays[overlayId]) {
       delete hintOverlays[overlayId];

--- a/packages/atri-app-core/src/editor-components/VisualHints/hintOverlays.ts
+++ b/packages/atri-app-core/src/editor-components/VisualHints/hintOverlays.ts
@@ -27,15 +27,20 @@ export function addOrModifyHintOverlays(overlays: {
   });
 }
 
-export function removeHintOverlays(overlayIds: string[]) {
+export function removeHintOverlays(
+  overlayIds: string[],
+  canvasZoneIdForSelectEnd?: string
+) {
   const affectedCanvasZones: Set<string> = new Set();
   overlayIds.forEach((overlayId) => {
     if (!hintOverlays[overlayId]) {
       return;
     }
     const overlay = hintOverlays[overlayId]!;
-    const canvasZoneId = componentStoreApi.getComponent(overlay.compId)!.parent
-      .canvasZoneId;
+    const canvasZoneId =
+      canvasZoneIdForSelectEnd !== undefined
+        ? canvasZoneIdForSelectEnd
+        : componentStoreApi.getComponent(overlay.compId)!.parent.canvasZoneId;
     affectedCanvasZones.add(canvasZoneId);
     if (hintOverlays[overlayId]) {
       delete hintOverlays[overlayId];


### PR DESCRIPTION
## Reference
Add reference to a related issue that this pull request is addressing. For example, fixes #


## Describe the pull request

Please describe the changes proposed in this pull request.
This PR intends to solve some bugs in the state machine:
- If the user `selected` a `component` and then clicked `outside a canvas zone` the component was still selected. The correct behaviour would be to transition into `Ready.Idle`.
- If a component gets deleted the `overlay wasn't removed` as the parent was undefined due to deletion of the component.

## Contributors (in case of a commit with multiple authors)

Co-authors:
